### PR TITLE
Add Root Directory to Index Script

### DIFF
--- a/web/index.py
+++ b/web/index.py
@@ -1,6 +1,16 @@
 #coding: utf-8
+import sys
 import os.path
 from datetime import datetime
+
+# Add the project root directory to sys.path
+# __file__ is the path to the current script (web/index.py)
+# os.path.dirname(__file__) is the directory of the current script (web/)
+# os.path.join(os.path.dirname(__file__), '..') is the parent directory (project root)
+# os.path.abspath(...) makes it an absolute path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
 
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
@@ -320,4 +330,4 @@ def __get_slide_json():
 	return True
 
 if __name__ == '__main__':
-	app.run(host="0.0.0.0", port=80, debug=True)
+	app.run(host="0.0.0.0", port=5000, debug=True)

--- a/web/index.py
+++ b/web/index.py
@@ -331,4 +331,4 @@ def __get_slide_json():
 	return True
 
 if __name__ == '__main__':
-	app.run(host="0.0.0.0", port=5000, debug=True)
+	app.run(host="0.0.0.0", port=80, debug=True)

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -7,12 +7,12 @@
     <meta http-equiv="Expires" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<script src="../static/jquery.js"></script>
-    <script src="../static/jquery-ui.js"></script>
-	<script src="../static/jquery.cookie.js"></script>
-    <script src="../static/jquery.ui.touch-punch.min.js"></script>
-    <script src="../static/worship.js"></script>
-    <link href="../static/jquery-ui.css" rel="stylesheet">
+	<script src="/static/jquery.js"></script>
+    <script src="/static/jquery-ui.js"></script>
+	<script src="/static/jquery.cookie.js"></script>
+    <script src="/static/jquery.ui.touch-punch.min.js"></script>
+    <script src="/static/worship.js"></script>
+    <link href="/static/jquery-ui.css" rel="stylesheet">
 
 <style>
 	body {

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -7,9 +7,9 @@
     <meta http-equiv="Expires" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<script src="/static/jquery.js"></script>
+    <script src="/static/jquery.js"></script>
     <script src="/static/jquery-ui.js"></script>
-	<script src="/static/jquery.cookie.js"></script>
+    <script src="/static/jquery.cookie.js"></script>
     <script src="/static/jquery.ui.touch-punch.min.js"></script>
     <script src="/static/worship.js"></script>
     <link href="/static/jquery-ui.css" rel="stylesheet">


### PR DESCRIPTION
The root directory isn't always explicitly correct when starting the script. This causes the Python script to fail when starting the server, due to being unable to find packages. Uses code stolen from @sfeng9 in index.py