### PR TITLE
Revealjs Fixes from papachen

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -628,7 +628,7 @@ def get_worship_songs(id):
     result = dB.run_para(sql, id)
     songs = []
 
-    style = {'align': '', 'background': '', 'opacity': 1, 'color': '', 'bgcolor': '', 'fragment': 0}
+    style = {'align': '', 'background': '', 'opacity': 1, 'color': '', 'bgcolor': '', 'fragment': 4}
     for r in result:
         if r[22] == 'info':
             songs.append({'type': r[22], 'title': r[19] if r[19] else r[18][0:10], 'author': '', 'lang': '', 'lang_2': '', 'key': '', 'sequence': '', 'bible': '', 'lyricist': '', 'book': '', 'copyright': '', 'ccli': '', 'lyrics_raw': '', 'content': '', 'video': '', 'score': '', 'date': r[14], 'id': r[21], 'transpose': r[16].split(','), 'alt_sequence': '', 'notes': r[18] if r[18] else '', 'version': r[20] if r[20] else '', 'style': style})

--- a/files/template.json
+++ b/files/template.json
@@ -15,7 +15,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "title":"安靜心",
       "type":"info"
@@ -35,7 +35,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "title":"報告",
       "type":"info"
@@ -55,7 +55,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "title":"肢體交通",
       "type":"info"
@@ -88,7 +88,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "title":"我的性命獻互祢",
       "type":"song"
@@ -102,7 +102,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "bible": "",
       "book": "",
@@ -131,7 +131,7 @@
          "opacity": 1,
          "color":"",
          "bgcolor":"",
-         "fragment": 0
+         "fragment": 4
       },
       "title":"祝禱 BENEDICTION",
       "type":"info"

--- a/web/index.py
+++ b/web/index.py
@@ -71,6 +71,7 @@ def handle_control(data):
 		if slides_data['pos'][0] != data['value'][0]: # When pos is different (new slide), change key to 0
 			slides_data['key'] = 0
 	slides_data[data['type']] = data['value']
+	slides_data['from'] = data['from']
 	emit('response', slides_data, broadcast=True)
 
 @socketio.on('msg')

--- a/web/static/presentation.js
+++ b/web/static/presentation.js
@@ -19,6 +19,7 @@
     let touchableElement;
     let w_id;
     let adding_slide = 0;
+    let slide_refreshed = false;
 
     // Socket Server url
     let socket_url = window.location.host;
@@ -86,14 +87,10 @@
     }
 
     function move_top(para) {
-        //scrollTo = $('div[' + para + ']');
         scrollTo = $('div[class="inner present"]');
         base = $('.preview').offset().top;
         $('.preview').scrollTop(base);
-        console.log(base, $(scrollTo).offset().top,  $(scrollTo).position())
-        $('.preview').animate({
-            scrollTop:$(scrollTo).offset().top - base
-        },'linear');
+        $('.preview').scrollTop($(scrollTo).offset().top - base);
     }
 
     function save_slides() {
@@ -143,44 +140,6 @@
         }
     }
 
-    function show_notes(text) {
-        text = text.replaceAll('\n', '<br/>');
-        return '>'+ text + '</div>';
-    }
-
-    function show_info(content, align) {
-        text = content.origin_text;
-        text = text.replaceAll('\n', '<br/>');
-        html = '<div class="' + mode + ' info origin" style="text-align:' + align + '">'  + text + '</div>';
-        if (content.region_text) {
-            text = content.region_text;
-            text = text.replaceAll('\n', '<br/>');
-            html += '<div class="' + mode + ' info region" style="text-align:' + align + '">'  + text + '</div>';
-        }
-        return html;
-    }
-
-    function show_lyrics(l, lang, lang_2) {
-        html = '<div class="' + mode + ' lyrics origin">' + l.origin_text + '</div>';
-        if (l.region_text) {
-            html += '<div class="' + mode + ' lyrics region">' + l.region_text + '</div>';
-        }
-        return html;
-    }
-
-    // function load_container(mode_name) {
-    //     container = {
-    //         'view': '<div id="top-left"></div><div id="top-right"></div><div id="preview" class="preview view"></div><div class="reveal"><div class="slides"></div></div><div id="bottom-left"></div><div id="bottom-right"></div>',
-    //         'musician': '<div id="top-left"></div><div id="top-right"></div><div id="preview" class="preview view"></div><div id="bottom-left"></div><div id="bottom-right"></div>',
-    //         'score': '<div id="top-left"></div><div id="top-right"></div><div id="preview" class="preview view"><object id="sheets" type="text/html" style="width:100%; height:100%; margin:1%;"></object></div><div id="bottom-left"></div><div id="bottom-right"></div>',
-    //         'lead': '<div id="top-right"></div><div class="preview_container"><div id="preview"></div><div id="menu"><div id="dynamic_btn"><br/><button name="dynamic" title="Intro">Intro</button><button name="dynamic" title="Interlude">Interlude</button><button name="dynamic" title="Ending">Ending</button><br/><button name="dynamic" title="Ready to Build up">Build Up</button><button name="dynamic" title="Slow Down">Slow Down</button><button name="dynamic" title="Speed Up">Speed Up</button><br/><button name="dynamic" title="Acapella">Acapella</button><button name="dynamic" title="Repeat Chorus">Repeat Chorus</button><button name="dynamic" title="Last Sentence">Last Sentence</button><div id="key_change"></div></div><div id="notes"></div></div><div id="preview_div"></div></div>'
-    //     }
-    //     if (mode_name) {
-    //         return container[mode_name];
-    //     }
-    //     return container[mode]
-    // }
-
     function create_view(type, origin, region, name) {
         let grid = document.createElement('div');
         grid.setAttribute('name', name);
@@ -206,10 +165,9 @@
         $('#slide_notes').html(slides[0].notes);
         for(var i=0;i<slides.length;i++) {
             data = slides[i];
-            bg = data.style.background;
+            bg_url = data.style.background;
             let section = document.createElement('section');
-            if (bg) {
-                bg_url = bg;
+            if (bg_url) {
                 bg_opacity = data.style.opacity
                 section.setAttribute('data-background-image', bg_url);
                 section.setAttribute('data-background-opacity', bg_opacity);
@@ -337,6 +295,7 @@
     }
 
     function update_json(download) {
+    $('#loading').show();
     data = JSON.stringify({"setting": setting, "slides": slides});
         $.ajax({
             type: "post",
@@ -355,6 +314,7 @@
                 }
             }
         });
+        $('#loading').hide();
     }
 
 
@@ -365,11 +325,15 @@
     });
 
     socket.on('reload', function (presentation) {
-        console.log('Admin reload json data');
         slides = presentation['data'];
+        console.log('Admin reload json data', slides);
         w_id = presentation['id'];
         adding_slide = 0;
-        location.reload()
+
+        // When reload is broadcast, load the slide from the data and sync it before move to current pos and order
+        load_slides();
+        Reveal.sync();
+        Reveal.slide(pos, order);
     });
 
     socket.on('response', function (data) {
@@ -377,13 +341,30 @@
         order = data.pos[1];
         msg = data.msg;
         dynamic = data.dynamic;
+        from = data.from;
         // TODO: For musician key change
         key_change = data.key;
-        console.log('Server sent: pos:', pos, 'order', order, 'msg:', msg, 'key:', key_change, 'dynamic:', dynamic);
-        Reveal.slide(pos, order);
-        show_data(pos);
-        show_msg();
+        console.log('Server sent: pos:', pos, 'order', order, 'msg:', msg, 'key:', key_change, 'dynamic:', dynamic, 'from:', from);
+        if (from!= mode) {
+            slide_refreshed = true;
+            Reveal.slide(pos, order);
+            change_slide();
+        }
     });
+
+    function change_slide() {
+        show_msg();
+        $('#top-left').html(slides[pos].title);
+        if(slides[pos].type=='media') {
+            $('#slide_notes').html(slides[pos].content.origin_text);
+        }
+        else {
+            $('#slide_notes').html(slides[pos].notes);
+        }
+        if(mode=='lead') {
+            load_preview();
+        }
+    }
 
 
     // contentEditable for origin, region, title, and notes

--- a/web/static/presentation.js
+++ b/web/static/presentation.js
@@ -264,12 +264,14 @@
 			                r_fragment = region_.splice(0, fragment).join('<br/>')
 				            let sub_section = document.createElement('section');
 				            sub_section.append(create_view(data.type, o_fragment, r_fragment, s_name));
+      			            sub_section.setAttribute('order', j);
       			            section.append(sub_section);
 			            }
 			        }
 			        else {
 				        let sub_section = document.createElement('section');
 				        sub_section.append(create_view(data.type, data.content[j].origin_text, data.content[j].region_text, s_name));
+      			        sub_section.setAttribute('order', j);
   			            section.append(sub_section);
     			    }
 			    }

--- a/web/static/presentation.js
+++ b/web/static/presentation.js
@@ -110,6 +110,9 @@
 
     function show_data(pos) {
         data = slides[pos];
+        // update admin/lead mode as well
+        $('#slide_title').html(data.title);
+        $('#slide_notes').html(data.notes)
         $('#top-left').html(data.title)
         if (mode == 'admin') {
             $('#fragment').empty();
@@ -159,10 +162,27 @@
         return grid;
     }
 
+    // Helper function to safely extract lines from either a list or raw text
+    function parseContent(htmlString) {
+        if (!htmlString) return { isList: false, lines: [] };
+
+        let tempDiv = document.createElement('div');
+        tempDiv.innerHTML = htmlString;
+        let listItems = tempDiv.querySelectorAll('li');
+
+        if (listItems.length > 0) {
+            return { isList: true, lines: Array.from(listItems).map(li => li.innerHTML) };
+        }
+        else {
+            let rawText = htmlString.replaceAll('\n', '<br/>');
+            return { isList: false, lines: rawText.split(/<br\s*\/?>/i).filter(n => n.trim() !== '') };
+        }
+    }
+
     function load_slides() {
         $('.slides').empty();
-        $('#slide_title').html(slides[0].title);
-        $('#slide_notes').html(slides[0].notes);
+        $('#slide_title').html(slides[pos].title);
+        $('#slide_notes').html(slides[pos].notes);
         for(var i=0;i<slides.length;i++) {
             data = slides[i];
             bg_url = data.style.background;
@@ -175,24 +195,8 @@
             fragment = data.style.fragment;
             if(data.type == 'info') {
                 // SETTING: Tune these numbers based on your presentation font size!
-                let max_lines_per_slide = 5; 
+                //let max_lines_per_slide = 5;
                 let max_chars_per_slide = 120; 
-
-                // Helper function to safely extract lines from either a list or raw text
-                function parseContent(htmlString) {
-                    if (!htmlString) return { isList: false, lines: [] };
-                    
-                    let tempDiv = document.createElement('div');
-                    tempDiv.innerHTML = htmlString;
-                    let listItems = tempDiv.querySelectorAll('li');
-                    
-                    if (listItems.length > 0) {
-                        return { isList: true, lines: Array.from(listItems).map(li => li.innerHTML) };
-                    } else {
-                        let rawText = htmlString.replaceAll('\n', '<br/>');
-                        return { isList: false, lines: rawText.split(/<br\s*\/?>/i).filter(n => n.trim() !== '') };
-                    }
-                }
 
                 let parsedOrigin = parseContent(data.content.origin_text);
                 let parsedRegion = parseContent(data.content.region_text);
@@ -201,20 +205,6 @@
                 let region_lines = parsedRegion.lines;
                 let isList = parsedOrigin.isList; 
 
-                if (fragment > 0) {
-                    // Fragment rendering remains unchanged
-                    while(origin_lines.length > 0) {
-                        let o_fragment = origin_lines.splice(0, fragment).map(obj => '<li>' + obj + '</li>').join('');
-                        let r_fragment = region_lines.splice(0, fragment).map(obj => '<li>' + obj + '</li>').join('');
-                        
-                        let sub_section = document.createElement('section');
-                        let ul = document.createElement('ul'); 
-                        ul.append(create_view(data.type, o_fragment, r_fragment, 'info'));
-                        sub_section.append(ul);
-                        section.append(sub_section);
-                    }
-                } 
-                else {
                     // NEW: Dynamic chunking based on both character count and line count
                     while (origin_lines.length > 0) {
                         let current_chunk_o = [];
@@ -232,7 +222,7 @@
                             // If we already have at least 1 line AND adding the next line 
                             // pushes us over the char limit OR the line limit, stop building this slide.
                             if (current_chunk_o.length > 0 && 
-                               (current_char_count + next_line_length > max_chars_per_slide || current_chunk_o.length >= max_lines_per_slide)) {
+                               (current_char_count + next_line_length > max_chars_per_slide || current_chunk_o.length >= fragment)) {
                                 break; 
                             }
 
@@ -262,14 +252,13 @@
                         sub_section.append(create_view(data.type, o_html, r_html, 'info'));
                         section.append(sub_section);
                     }
-                }
             }
 		    else if (data.type == 'song') {
 			    for(var j=0;j<data.content.length;j++) {
 			        s_name = data.content[j].name;
 			        if (fragment > 0) {
-			            origin_ = data.content[j].origin_text.split('<br/>').filter(n => n);
-			            region_ = data.content[j].region_text.split('<br/>').filter(n => n);
+			            origin_ = data.content[j].origin_text.split(/<br\/?>/).filter(n => n);
+			            region_ = data.content[j].region_text.split(/<br\/?>/).filter(n => n);
 			            while(origin_.length>0) {
 			                o_fragment = origin_.splice(0, fragment).join('<br/>')
 			                r_fragment = region_.splice(0, fragment).join('<br/>')
@@ -334,6 +323,7 @@
         load_slides();
         Reveal.sync();
         Reveal.slide(pos, order);
+        change_slide();
     });
 
     socket.on('response', function (data) {
@@ -353,14 +343,8 @@
     });
 
     function change_slide() {
+        show_data(pos);
         show_msg();
-        $('#top-left').html(slides[pos].title);
-        if(slides[pos].type=='media') {
-            $('#slide_notes').html(slides[pos].content.origin_text);
-        }
-        else {
-            $('#slide_notes').html(slides[pos].notes);
-        }
         if(mode=='lead') {
             load_preview();
         }

--- a/web/templates/slides/slides_admin.html
+++ b/web/templates/slides/slides_admin.html
@@ -160,7 +160,7 @@
 
 {% block extra_js %}
 <script>
-        mode = 'admin';                 // Set mode to lead
+        mode = 'admin';                 // Set mode to admin
         bg_url = '';
         bg_opacity = 1;
         a_type = '';
@@ -408,6 +408,7 @@
             update_current_bg();
             $('#edit_btn').css('left', $('.reveal').width()-100);
             $('#edit_btn').show();
+            a_type = 'bg';
         });
 
         function update_current_bg() {
@@ -529,17 +530,16 @@
         });
 
         Reveal.on('slidechanged', (event) => {
+            if(slide_refreshed) {            // slide refreshed by socket, reset flag
+                slide_refreshed = false;
+                return true;
+            }
             pos = event.indexh;
             order = event.indexv;
             pre = $(event.previousSlide).children().attr('name');
             cur = $(event.currentSlide).children().attr('name');
-            $('#slide_title').html(slides[pos].title);
-            if(slides[pos].type=='media') {
-                $('#slide_notes').html(slides[pos].content.origin_text);
-            }
-            else {
-                $('#slide_notes').html(slides[pos].notes);
-            }
+            change_slide();
+
             if (order == 0) {
                 content_index = 0;
             }
@@ -551,7 +551,7 @@
                 load_slides();
             }
             console.log("slide changed", pos, order, content_index);
-            socket.emit('control', {'type': 'pos', 'value': [pos, order]});
+            socket.emit('control', {'type': 'pos', 'value': [pos, order], 'from': 'admin'});
         });
 </script>
 {% endblock %}

--- a/web/templates/slides/slides_admin.html
+++ b/web/templates/slides/slides_admin.html
@@ -377,18 +377,25 @@
 
         $(document).on('change', '[contenteditable]', function() {
             element_class = $(this).attr('class');
+            order_num = $(this).parent().parent().attr('order');
             // Getting the root section of the changed div in order to loop through all content
             section_root = $(this).parent().parent().parent();
-            new_data = '';
+            var new_data = [];
             section_root.children().each(function() {
-                html = $(this).find('.'+element_class.replace(' ','.')).html();
-                new_data += html + '<br/>'; // Add <br> for the last line
+                if ($(this).attr('order') == order_num) {
+                    sub_section = $(this).find('.'+element_class.replace(' ','.'));
+                    if(sub_section.text()!='') {
+                        html = sub_section.html();
+                        new_data.push(html);
+                    }
+                }
             });
-            new_data = new_data.slice(0, -5); // Remove last <br/>
+            new_data = new_data.filter(n => n); // Remove empty entries
+            new_data = new_data.join('<br/>');
 
             if(element_class.indexOf('origin')>0) {
                 if(element_class.indexOf('song')>=0) {
-                    slides[pos].content[order].origin_text = new_data;
+                    slides[pos].content[order_num].origin_text = new_data;
                 }
                 else {
                     slides[pos].content.origin_text = new_data;
@@ -396,7 +403,7 @@
             }
             else if(element_class.indexOf('region')>0) {
                 if(element_class.indexOf('song')>=0) {
-                    slides[pos].content[order].region_text = new_data;
+                    slides[pos].content[order_num].region_text = new_data;
                 }
                 else {
                     slides[pos].content.region_text = new_data;

--- a/web/templates/slides/slides_admin.html
+++ b/web/templates/slides/slides_admin.html
@@ -267,7 +267,7 @@
         function add_media_slide() {
             link = prompt('Enter the link to insert to current slide');
             if(link) {
-                info = {"alt_sequence": "", "author": "", "style": {"align": "", "background": "", "opacity": 1, "fragment": 0, "color": ""}, "bible": "", "book": "", "ccli": "", "content": {"origin_text": link, "region_text": ""}, "copyright": "", "date": "", "id": -1, "key": "", "lang": "", "lang_2": "", "lyricist": "", "lyrics_raw": "", "notes": "Media", "score": "", "sequence": "", "title": "Media", "transpose": "0", "type": "media", "version": "", "video": ""};
+                info = {"alt_sequence": "", "author": "", "style": {"align": "", "background": "", "opacity": 1, "fragment": 4, "color": ""}, "bible": "", "book": "", "ccli": "", "content": {"origin_text": link, "region_text": ""}, "copyright": "", "date": "", "id": -1, "key": "", "lang": "", "lang_2": "", "lyricist": "", "lyrics_raw": "", "notes": "Media", "score": "", "sequence": "", "title": "Media", "transpose": "0", "type": "media", "version": "", "video": ""};
                 slides.splice(pos+1, 0, info);
                 adding_slide = 0;
                 update_json();
@@ -355,12 +355,52 @@
             }
         });
 
-        $('div').on('change', '[contenteditable]', function() {
-            if($(this).attr('class').indexOf('origin')>0) {
-                slides[pos].content.origin_text = $(this).html();
+        // Helper to use the correct tag when return is enter in the div
+        $(document).on('keydown', '[contenteditable=true]', function(e) {
+            // trap the return key being pressed
+            if (e.keyCode == 13) {
+                if(e.target.innerHTML.includes('<li>')) {
+                    console.log('<li>', 'Do nothing...');
+                }
+                else if(e.target.innerHTML.includes('<p>')){
+                    console.log('<p>', 'insert line break');
+                    document.execCommand('insertLineBreak');
+                    return false;
+                }
+                else {
+                    console.log('<div>', 'insert br');
+                    document.execCommand('insertLineBreak');
+                    return false;
+                }
             }
-            else if($(this).attr('class').indexOf('region')>0) {
-                slides[pos].content.region_text = $(this).html();
+        });
+
+        $(document).on('change', '[contenteditable]', function() {
+            element_class = $(this).attr('class');
+            // Getting the root section of the changed div in order to loop through all content
+            section_root = $(this).parent().parent().parent();
+            new_data = '';
+            section_root.children().each(function() {
+                html = $(this).find('.'+element_class.replace(' ','.')).html();
+                new_data += html + '<br/>'; // Add <br> for the last line
+            });
+            new_data = new_data.slice(0, -5); // Remove last <br/>
+
+            if(element_class.indexOf('origin')>0) {
+                if(element_class.indexOf('song')>=0) {
+                    slides[pos].content[order].origin_text = new_data;
+                }
+                else {
+                    slides[pos].content.origin_text = new_data;
+                }
+            }
+            else if(element_class.indexOf('region')>0) {
+                if(element_class.indexOf('song')>=0) {
+                    slides[pos].content[order].region_text = new_data;
+                }
+                else {
+                    slides[pos].content.region_text = new_data;
+                }
             }
             else if($(this).attr('id') == 'slide_title') {
                 slides[pos].title = $(this).html();
@@ -451,7 +491,7 @@
                     return false;
                 }
                 else {
-                    info = {"alt_sequence": "", "author": "", "style": {"align": "", "background": "", "opacity": 1, "fragment": 0, "color": ""}, "bible": "", "book": "", "ccli": "", "content": {"origin_text": origin, "region_text": region}, "copyright": "", "date": "", "id": 115, "key": "", "lang": "", "lang_2": "", "lyricist": "", "lyrics_raw": "", "notes": "歡迎報告", "score": "", "sequence": "", "title": "Information", "transpose": "0", "type": "info", "version": "", "video": ""};
+                    info = {"alt_sequence": "", "author": "", "style": {"align": "", "background": "", "opacity": 1, "fragment": 4, "color": ""}, "bible": "", "book": "", "ccli": "", "content": {"origin_text": origin, "region_text": region}, "copyright": "", "date": "", "id": 115, "key": "", "lang": "", "lang_2": "", "lyricist": "", "lyrics_raw": "", "notes": "歡迎報告", "score": "", "sequence": "", "title": "Information", "transpose": "0", "type": "info", "version": "", "video": ""};
                     slides.splice(pos+1, 0, info);
                     $('#edit_btn').hide();
                     adding_slide = 0;

--- a/web/templates/slides/slides_lead.html
+++ b/web/templates/slides/slides_lead.html
@@ -145,7 +145,7 @@
 </div>
 </body>
 <script>
-    mode = 'lead';
+    mode = 'lead';                 // Set mode to lead
     presentation = {{ presentation|safe }};
     slides = presentation['data'];
     setting = presentation['setting'];
@@ -205,22 +205,25 @@
         }
     });
 
+    Reveal.on('ready', (event) => {
+        // Move slide to current pos and order when it's ready
+        Reveal.slide(pos, order);
+    });
+
     Reveal.on('slidechanged', (event) => {
-        pos = event.indexh;
-        order = event.indexv;
+        if(slide_refreshed) {            // slide refreshed by socket, reset flag
+            slide_refreshed = false;
+            return true;
+        }
+        console.log('here', event.indexh, pos, event.indexv, order)
         pre = $(event.previousSlide).children().attr('name');
         cur = $(event.currentSlide).children().attr('name');
-        $('#top-left').html(slides[pos].title);
-        if(slides[pos].type=='media') {
-            $('#slide_notes').html(slides[pos].content.origin_text);
-        }
-        else {
-            $('#slide_notes').html(slides[pos].notes);
-        }
-        load_preview();
+        pos = event.indexh;
+        order = event.indexv;
+        change_slide()
 
         console.log("slide changed, emit changes to server", pos, order);
-        socket.emit('control', {'type': 'pos', 'value': [pos, order]});
+        socket.emit('control', {'type': 'pos', 'value': [pos, order], 'from': 'lead'});
     });
 
     // Stuff copied from original slides.html, I believe it was for buttons

--- a/web/templates/slides/slides_view.html
+++ b/web/templates/slides/slides_view.html
@@ -44,27 +44,6 @@
         order = presentation['pos'][1];
         msg = presentation['msg'];
 
-    function init() {
-        if (slides.length == 0 || mode == '') {
-            alert("No slide is currently running!!");
-            //mode = '';
-            return false;
-        }
-
-        // $("#control_btn").hide();
-        // $("#container").html(load_container());
-
-        // preview = $('#preview');
-        // load(preview);
-
-        // if (mode == 'lead') {
-        //     $("#preview").css('height', '75vh');
-        // }
-        // else if (mode == 'view' || mode == 'musician') {
-        //     $('#header').hide();
-        // }
-    }
-
     $(document).ready(function() {
         $('#header').hide();
 		Reveal.initialize({
@@ -75,17 +54,11 @@
 			progress: false,
 			controls: false
 		});
-
         load_slides();
-        
     });
 
-    Reveal.on('slidechanged', (event) => {
-        pos = event.indexh;
-        order = event.indexv;
-        console.log("slide changed", pos, order);
+    Reveal.on('ready', (event) => {
         Reveal.slide(pos, order);
-        show_data(pos);
     });
 
 </script>

--- a/web/templates/slides/slides_view.html
+++ b/web/templates/slides/slides_view.html
@@ -61,6 +61,11 @@
         Reveal.slide(pos, order);
     });
 
+    Reveal.on('slidechanged', (event) => {
+        pos = event.indexh;
+        order = event.indexv;
+        change_slide()
+    });
 </script>
 </head>
 <body>


### PR DESCRIPTION
Resolved #34 , When response broadcast, re-draw the slides, sync, and move to current slide

Resolved #35  - Add "from" to determine who sent socket.emit. Only change slide when "response" is sent by other mode
Added a variable "slide_refreshed" as flag to avoid double socket.emit

Resolved #36  - Add Reveal.slide(pos, order) inside Reveal.ready event so that it will always load the current slide

Resolved #37  - get rid of animate in move_top