### PR TITLE
Multilingual db Feature

### DIFF
--- a/app/conf.json
+++ b/app/conf.json
@@ -42,7 +42,7 @@
       "default": {
         "name": "worship.db",
         "search": {
-            "query": "select s.song_id, s.title, s.lang, s.lang_2, s.song_key, (select link from media m where m.song_id=s.song_id and m_type='video') as video, (select link from media m where m.song_id=s.song_id and m_type='score') as score, (select abc from media m where m.song_id=s.song_id and m_type='abc') as abc from songs s where {} group by s.song_id",
+            "query": "select s.song_id, s.title, s.lang, s.lang_2, s.song_key, (select group_concat(link, ';;;') from media m where m.song_id=s.song_id and m_type='video') as video, (select group_concat(link, ';;;') from media m where m.song_id=s.song_id and m_type='score') as score, (select group_concat(abc, ';;;') from media m where m.song_id=s.song_id and m_type='abc') as abc from songs s where {} group by s.song_id",
             "columns": [
               "s.title",
               "s.content"

--- a/app/tools.py
+++ b/app/tools.py
@@ -99,13 +99,15 @@ def simplify_json(json):
     slides = json['slides']
     simple = []
     for slide in slides:
-        contents = slide['content']
+        contents = slide.get('content', [])
         cc = []
         temp = {key: slide[key] for key in slide.keys() & {'id', 'title', 'notes', 'style', 'author', 'lyricist', 'ccli', 'book', 'copyright', 'key', 'type'}}
         if isinstance(contents, list):
             for content in contents:
-                cc.append(
-                    {key: content[key] for key in content.keys() & {'name', 'origin_text', 'region_text'}})
+                if isinstance(content, dict):
+                    cc.append({key: content[key] for key in content.keys() & {'name', 'origin_text', 'region_text'}})
+                else:
+                    cc.append({'origin_text': content})
             temp['content'] = cc
         else:
             temp['content'] = contents
@@ -176,7 +178,14 @@ def create_json(id, worship=None):
         template["announcement"]["content"]["region_text"] = a_region
         template["caring"]["content"]["origin_text"] = c_origin
         template["caring"]["content"]["region_text"] = c_region
-        template["sermon"]["content"]["origin_text"] = '{title}<br/>{bible}<br/>{speaker}<br/>{outline}'.format(bible=sermon['bible'], title=sermon['title'], outline=sermon['outline'], speaker=sermon['speaker'])
+        sermons = sermon.get('sermons', {}) or {}
+        sermon_variant = next((sermons.get(lang) or {} for lang in ['zh', 'zh-TW', 'en'] if (sermons.get(lang) or {}).get('title') or (sermons.get(lang) or {}).get('speaker') or (sermons.get(lang) or {}).get('bible') or (sermons.get(lang) or {}).get('outline')), {})
+        template["sermon"]["content"]["origin_text"] = '{title}<br/>{bible}<br/>{speaker}<br/>{outline}'.format(
+            title=sermon_variant.get('title', ''),
+            bible=sermon_variant.get('bible', ''),
+            speaker=sermon_variant.get('speaker', ''),
+            outline=sermon_variant.get('outline', ''),
+        )
 
         order = template["order"]
         temp = []

--- a/app/utils.py
+++ b/app/utils.py
@@ -620,24 +620,64 @@ def edit_songset(id, content):
 def update_sermon(data):
     w_date = data["date"]
     w_notes = data["notes"] if "notes" in data else None
-    values = []
-    sql = "update sermon set "
+
+    fields = {}
     for key, val in data.items():
-        if key != 'notes' and key != 'date':
-            sql += key + "= ?,"
-            values.append(val)
-    if len(values) > 0:
-        values.append(w_date)
-        sql = sql[:-1] + " where date = ?"
-        dB.run_para(sql, values)
-    if w_notes:
-        sql = "update worship set notes=? where scheduled_date=?"
-        dB.run_para(sql, [w_notes, w_date])
+        if key in ['notes', 'date']:
+            continue
+        if key in ['title_en', 'title_zh', 'speaker_en', 'speaker_zh', 'verse_en', 'verse_zh', 'is_joint']:
+            fields[key] = val
+        elif key in ['title', 'speaker', 'bible_verse', 'outline']:
+            if key == 'title':
+                fields['title_en'] = val
+                fields['title_zh'] = val
+            elif key == 'speaker':
+                fields['speaker_en'] = val
+                fields['speaker_zh'] = val
+            elif key == 'bible_verse':
+                fields['verse_en'] = val
+                fields['verse_zh'] = val
+
+    if fields:
+        assignments = ', '.join([f"{k} = ?" for k in fields.keys()])
+        values = list(fields.values()) + [w_date]
+        dB.run_para(f"update sermon set {assignments} where date = ?", values)
+
+    if w_notes is not None:
+        dB.run_para("update worship set notes=? where scheduled_date=?", [w_notes, w_date])
+
+
+def _get_sermon_display_fields(title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, outline, is_joint):
+    return {
+        'title': title_en or title_zh or '',
+        'title_en': title_en or '',
+        'title_zh': title_zh or '',
+        'speaker': speaker_en or speaker_zh or '',
+        'speaker_en': speaker_en or '',
+        'speaker_zh': speaker_zh or '',
+        'bible': verse_en or verse_zh or '',
+        'bible_en': verse_en or '',
+        'bible_zh': verse_zh or '',
+        'outline': outline or '',
+        'is_joint': bool(is_joint) if is_joint is not None else False
+    }
+
 
 def get_worship(id):
-    sql = "select notes, scheduled_date, s.title, s.speaker, s.bible_verse, s.outline from worship w inner join sermon s on w.scheduled_date = s.date where worship_id = ?"
+    sql = """
+        select notes, scheduled_date, s.title_en, s.title_zh, s.speaker_en, s.speaker_zh,
+               s.verse_en, s.verse_zh, s.outline, s.is_joint
+        from worship w
+        inner join sermon s on w.scheduled_date = s.date
+        where worship_id = ?
+    """
     r = dB.run_para(sql, id)[0]
-    return {'date': r[1], 'title': r[2] if r[2] else '', 'notes': r[0] if r[0] else '', 'speaker': r[3] if r[3] else '', 'bible': r[4] if r[4] else '', 'outline': r[5] if r[5] else ''}
+    sermon_fields = _get_sermon_display_fields(r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9])
+    return {
+        'date': r[1],
+        'notes': r[0] if r[0] else '',
+        **sermon_fields
+    }
 
 def get_worship_date(id):
     sql = "select scheduled_date from worship where worship_id = ?"
@@ -671,18 +711,57 @@ def get_availablity():
 
 def worship_list(id=None):
     if id:
-        sql = "select s.title, s.speaker, case when t.name then t.name else t.name_2 end, (select i.name from instrument i where i.id = it.instrument_id), w.title, w.scheduled_date, w.worship_id, s.bible_verse, s.outline, w.notes from worship w inner join sermon s on w.scheduled_date = s.date left join instrument_team it on w.worship_id = it.worship_id left join team t on it.user_id = t.user_id where w.worship_id=? and it.instrument_id <> -1 order by w.scheduled_date, it.instrument_id"
+        sql = """
+            select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
+                   case when t.name then t.name else t.name_2 end,
+                   (select i.name from instrument i where i.id = it.instrument_id),
+                   w.title, w.scheduled_date, w.worship_id, s.outline, w.notes, s.is_joint
+            from worship w
+            inner join sermon s on w.scheduled_date = s.date
+            left join instrument_team it on w.worship_id = it.worship_id
+            left join team t on it.user_id = t.user_id
+            where w.worship_id=? and it.instrument_id <> -1
+            order by w.scheduled_date, it.instrument_id
+        """
         result = dB.run_para(sql, id)
     else:
-        sql = "select s.title, s.speaker, case when t.name then t.name else t.name_2 end, (select i.name from instrument i where i.id = it.instrument_id), w.title, w.scheduled_date, w.worship_id, s.bible_verse, s.outline, w.notes from worship w inner join sermon s on w.scheduled_date = s.date left join instrument_team it on w.worship_id = it.worship_id left join team t on it.user_id = t.user_id order by w.scheduled_date, it.instrument_id"
+        sql = """
+            select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
+                   case when t.name then t.name else t.name_2 end,
+                   (select i.name from instrument i where i.id = it.instrument_id),
+                   w.title, w.scheduled_date, w.worship_id, s.outline, w.notes, s.is_joint
+            from worship w
+            inner join sermon s on w.scheduled_date = s.date
+            left join instrument_team it on w.worship_id = it.worship_id
+            left join team t on it.user_id = t.user_id
+            order by w.scheduled_date, it.instrument_id
+        """
         result = dB.run(sql)
     worship = []
     for r in result:
-        a = next((x for x in worship if x['date'] == r[5]), None)
-        if a and r[3]:
-            a['content'].append({'user_name': r[2], 'role': r[3]})
+        a = next((x for x in worship if x['date'] == r[9]), None)
+        if a and (r[6] or r[7]):
+            a['content'].append({'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''})
         else:
-            worship.append({'worship_id': r[6], 'date': r[5] if r[5] else '', 'worship_title': r[4] if r[4] else '', 'sermon_title': r[0] if r[0] else '', 'speaker': r[1] if r[1] else '', 'bible': r[7] if r[7] else '', 'outline': r[8] if r[8] else '', 'notes': r[9] if r[9] else '', 'content': [{'user_name': r[2] if r[2] else '', 'role': r[3] if r[3] else ''}]})
+            sermon_fields = _get_sermon_display_fields(r[0], r[1], r[2], r[3], r[4], r[5], r[11], r[13])
+            worship.append({
+                'worship_id': r[10],
+                'date': r[9] if r[9] else '',
+                'worship_title': r[8] if r[8] else '',
+                'sermon_title': sermon_fields['title'],
+                'title_en': sermon_fields['title_en'],
+                'title_zh': sermon_fields['title_zh'],
+                'speaker': sermon_fields['speaker'],
+                'speaker_en': sermon_fields['speaker_en'],
+                'speaker_zh': sermon_fields['speaker_zh'],
+                'bible': sermon_fields['bible'],
+                'bible_en': sermon_fields['bible_en'],
+                'bible_zh': sermon_fields['bible_zh'],
+                'outline': sermon_fields['outline'],
+                'notes': r[12] if r[12] else '',
+                'is_joint': sermon_fields['is_joint'],
+                'content': [{'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''}]
+            })
     return worship
 
 def get_api_key(name):

--- a/app/utils.py
+++ b/app/utils.py
@@ -55,7 +55,19 @@ def search_song_efcnc(keyword):
         "cols": db["search"]["columns"]
     }
     result = dB.search(para)
-    titles = [{'id': x[0], 'title': x[1], 'lang': x[2] if x[2] else '', 'lang_2': x[3] if x[3] else '', 'key': x[4] if x[4] else '', 'video': x[5] if x[5] else '', 'score': x[6] if x[6] else '', 'abc': x[0] if x[7] else ''} for x in result]
+    
+    # Split the media strings into arrays so the frontend get_links() function can iterate over them
+    titles = [{
+        'id': x[0], 
+        'title': x[1], 
+        'lang': x[2] if x[2] else '', 
+        'lang_2': x[3] if x[3] else '', 
+        'key': x[4] if x[4] else '', 
+        'video': x[5].split(';;;') if x[5] else [], 
+        'score': x[6].split(';;;') if x[6] else [], 
+        'abc': x[7].split(';;;') if x[7] else []
+    } for x in result]
+    
     return titles
 
 def bible_books(translation):
@@ -344,16 +356,31 @@ def get_songs_para(days, count=None):
             content.append({'count': r[0], 'title': r[1], 'id': r[2]})
         return content
     else:
-        sql = "select p.scheduled_date, s.title, s.song_id, s.lang, s.lang_2, s.song_key from presentation p inner join songs s on s.song_id = p.song_id where julianday('now') - julianday(p.scheduled_date) <= {} order by p.scheduled_date desc, s.title".format(days)
+        # Changed delimiter from '||' to ';;;' to avoid breaking ABC notation
+        sql = """select p.scheduled_date, s.title, s.song_id, s.lang, s.lang_2, s.song_key,
+                 (select group_concat(link, ';;;') from media m where m.song_id=s.song_id and m_type='video') as video,
+                 (select group_concat(link, ';;;') from media m where m.song_id=s.song_id and m_type='score') as score,
+                 (select group_concat(abc, ';;;') from media m where m.song_id=s.song_id and m_type='abc') as abc 
+                 from presentation p inner join songs s on s.song_id = p.song_id 
+                 where julianday('now') - julianday(p.scheduled_date) <= {} 
+                 order by p.scheduled_date desc, s.title""".format(days)
         result = dB.run(sql)
         content = {}
-        temp = []
         for r in result:
-            if r[0] in content.keys():
-                temp.append({'id': r[2], 'title': r[1], 'lang': r[3], 'lang_2': r[4] if r[4] else '', 'key': r[5]})
-            else:
-                content[r[0]] = temp
-                temp = []
+            song_data = {
+                'id': r[2], 
+                'title': r[1], 
+                'lang': r[3], 
+                'lang_2': r[4] if r[4] else '', 
+                'key': r[5],
+                'video': r[6].split(';;;') if r[6] else [],
+                'score': r[7].split(';;;') if r[7] else [],
+                'abc': r[8].split(';;;') if r[8] else []
+            }
+            if r[0] not in content:
+                content[r[0]] = []
+            content[r[0]].append(song_data)
+            
         return content
 
 def get_songs(ids=None):
@@ -365,18 +392,34 @@ def get_songs(ids=None):
     else:
         sql += ' order by s.song_id desc'
         result = dB.run(sql)
+    
     songs = []
     for r in result:
         temp = next((x for x in songs if x['title'] == r[0]), None)
         if temp:
-            if r[13] == 'video':
+            # Append subsequent media entries if the song object already exists
+            if r[13] == 'video' and r[12]:
                 temp['video'].append(r[12])
-            elif r[13] == 'score':
+            elif r[13] == 'score' and r[12]:
                 temp['score'].append(r[12])
-            elif r[13] == 'abc':
-                temp['abc'] = r[15]
+            elif r[13] == 'abc' and r[14]:
+                temp['abc'].append(r[14])
         else:
-            songs.append({'type': 'song', 'title': r[0], 'author': r[1] if r[1] else '', 'lang': r[2] if r[2] else '', 'lang_2': r[3] if r[3] else '', 'key': r[4] if r[4] else '', 'sequence': r[5] if r[5] else '', 'bible': r[6] if r[6] else '', 'lyricist': r[7] if r[7] else '', 'book': r[8] if r[8] else '', 'copyright': r[9] if r[9] else '', 'ccli': r[10] if r[10] else '', 'lyrics_raw': r[11], 'content': Parser.parse_lyrics(r[11], r[5]), 'video': [r[12]] if r[13] == 'video' else [], 'score': [r[12]] if r[13] == 'score' else [], 'abc': r[15] if r[13] == 'abc' and r[14] else '', 'id': r[15], 'notes': '', 'transpose': ['0'], 'alt_sequence': r[5] if r[5] else ''})
+            # Initialize arrays safely on creation
+            songs.append({
+                'type': 'song', 'title': r[0], 'author': r[1] if r[1] else '', 
+                'lang': r[2] if r[2] else '', 'lang_2': r[3] if r[3] else '', 
+                'key': r[4] if r[4] else '', 'sequence': r[5] if r[5] else '', 
+                'bible': r[6] if r[6] else '', 'lyricist': r[7] if r[7] else '', 
+                'book': r[8] if r[8] else '', 'copyright': r[9] if r[9] else '', 
+                'ccli': r[10] if r[10] else '', 'lyrics_raw': r[11], 
+                'content': Parser.parse_lyrics(r[11], r[5]), 
+                'video': [r[12]] if r[13] == 'video' and r[12] else [], 
+                'score': [r[12]] if r[13] == 'score' and r[12] else [], 
+                'abc': [r[14]] if r[13] == 'abc' and r[14] else [], 
+                'id': r[15], 'notes': '', 'transpose': ['0'], 
+                'alt_sequence': r[5] if r[5] else ''
+            })
     return songs
 
 def get_song_sheet(ids=None):

--- a/app/utils.py
+++ b/app/utils.py
@@ -773,7 +773,7 @@ def get_worship_id(date):
     return r
 
 def get_worship_songs(id):
-    sql = "select s.title, s.author, s.lang, s.lang_2, s.song_key, s.sequence, s.bible_verse, s.lyricist, s.book, s.copyright, s.ccli, s.content, (select link from media m where m.song_id=s.song_id and m_type='video') as video, (select link from media m where m.song_id=s.song_id and m_type='score') as score, w.scheduled_date as date, se.song_id as id, se.transpose as transpose, se.sequence alt_sequence, se.notes as notes, se.bible, se.version, se.rowid, se.type, (select abc from media m where m.song_id=s.song_id and m_type='abc') as abc from presentation se left join songs s on s.song_id = se.song_id  inner join worship w on w.scheduled_date = se.scheduled_date where se.worship_id = ? order by se.song_order"
+    sql = "select s.title, s.author, s.lang, s.lang_2, s.song_key, s.sequence, s.bible_verse, s.lyricist, s.book, s.copyright, s.ccli, s.content, (select group_concat(link, '||') from media m where m.song_id=s.song_id and m_type='video') as video, (select group_concat(link, '||') from media m where m.song_id=s.song_id and m_type='score') as score, w.scheduled_date as date, se.song_id as id, se.transpose as transpose, se.sequence alt_sequence, se.notes as notes, se.bible, se.version, se.rowid, se.type, (select group_concat(abc, '||') from media m where m.song_id=s.song_id and m_type='abc') as abc from presentation se left join songs s on s.song_id = se.song_id  inner join worship w on w.scheduled_date = se.scheduled_date where se.worship_id = ? order by se.song_order"
     result = dB.run_para(sql, id)
     songs = []
 
@@ -781,7 +781,11 @@ def get_worship_songs(id):
         if r[22] == 'info':
             songs.append({'type': r[22], 'title': r[19] if r[19] else r[18][0:10], 'author': '', 'lang': '', 'lang_2': '', 'song_key': '', 'sequence': '', 'bible_verse': '', 'lyricist': '', 'book': '', 'copyright': '', 'ccli': '', 'lyrics_raw': '', 'content': '', 'video': '', 'score': '', 'date': r[14], 'id': r[21], 'transpose': r[16].split(','), 'alt_sequence': '', 'notes': r[18] if r[18] else '', 'version': r[20] if r[20] else ''})
         elif r[22] == 'song':
-            songs.append({'type': r[22], 'title': r[0], 'author': r[1] if r[1] else '', 'lang': r[2] if r[2] else '', 'lang_2': r[3] if r[3] else '', 'song_key': r[4] if r[4] else '', 'sequence': r[5] if r[5] else '', 'bible_verse': r[6] if r[6] else '', 'lyricist': r[7] if r[7] else '', 'book': r[8] if r[8] else '', 'copyright': r[9] if r[9] else '', 'ccli': r[10] if r[10] else '', 'lyrics_raw': r[11], 'content': Parser.parse_lyrics(r[11], r[17]), 'video': r[12] if r[12] else '', 'score': r[13] if r[13] else '', 'date': r[14], 'id': r[15], 'transpose': r[16].split(',') if r[16] else [0], 'alt_sequence': r[17] if r[17] else '', 'notes': r[18] if r[18] else '', 'abc': r[23] if r[23] else ''})
+            songs.append({'type': r[22], 'title': r[0], 'author': r[1] if r[1] else '', 'lang': r[2] if r[2] else '', 'lang_2': r[3] if r[3] else '', 'song_key': r[4] if r[4] else '', 'sequence': r[5] if r[5] else '', 'bible_verse': r[6] if r[6] else '', 'lyricist': r[7] if r[7] else '', 'book': r[8] if r[8] else '', 'copyright': r[9] if r[9] else '', 'ccli': r[10] if r[10] else '', 'lyrics_raw': r[11], 'content': Parser.parse_lyrics(r[11], r[17]), 
+            'video': r[12].split('||') if r[12] else [], 
+            'score': r[13].split('||') if r[13] else [], 
+            'date': r[14], 'id': r[15], 'transpose': r[16].split(',') if r[16] else [0], 'alt_sequence': r[17] if r[17] else '', 'notes': r[18] if r[18] else '', 
+            'abc': r[23].split('||') if r[23] else []})
     return songs
 
 def get_availablity():

--- a/app/utils.py
+++ b/app/utils.py
@@ -625,7 +625,7 @@ def update_sermon(data):
     for key, val in data.items():
         if key in ['notes', 'date']:
             continue
-        if key in ['title_en', 'title_zh', 'speaker_en', 'speaker_zh', 'verse_en', 'verse_zh', 'is_joint']:
+        if key in ['title_en', 'title_zh', 'speaker_en', 'speaker_zh', 'verse_en', 'verse_zh', 'outline_en', 'outline_zh', 'is_joint']:
             fields[key] = val
         elif key in ['title', 'speaker', 'bible_verse', 'outline']:
             if key == 'title':
@@ -637,6 +637,8 @@ def update_sermon(data):
             elif key == 'bible_verse':
                 fields['verse_en'] = val
                 fields['verse_zh'] = val
+            elif key == 'outline':
+                fields['outline_zh'] = val
 
     if fields:
         assignments = ', '.join([f"{k} = ?" for k in fields.keys()])
@@ -647,18 +649,16 @@ def update_sermon(data):
         dB.run_para("update worship set notes=? where scheduled_date=?", [w_notes, w_date])
 
 
-def _get_sermon_display_fields(title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, outline, is_joint):
+def _get_sermon_display_fields(title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, outline_en, outline_zh, is_joint):
     return {
-        'title': title_en or title_zh or '',
         'title_en': title_en or '',
         'title_zh': title_zh or '',
-        'speaker': speaker_en or speaker_zh or '',
         'speaker_en': speaker_en or '',
         'speaker_zh': speaker_zh or '',
-        'bible': verse_en or verse_zh or '',
         'bible_en': verse_en or '',
         'bible_zh': verse_zh or '',
-        'outline': outline or '',
+        'outline_en': outline_en or '',
+        'outline_zh': outline_zh or '',
         'is_joint': bool(is_joint) if is_joint is not None else False
     }
 
@@ -666,13 +666,13 @@ def _get_sermon_display_fields(title_en, title_zh, speaker_en, speaker_zh, verse
 def get_worship(id):
     sql = """
         select notes, scheduled_date, s.title_en, s.title_zh, s.speaker_en, s.speaker_zh,
-               s.verse_en, s.verse_zh, s.outline, s.is_joint
+               s.verse_en, s.verse_zh, s.outline_en, s.outline_zh, s.is_joint
         from worship w
         inner join sermon s on w.scheduled_date = s.date
         where worship_id = ?
     """
     r = dB.run_para(sql, id)[0]
-    sermon_fields = _get_sermon_display_fields(r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9])
+    sermon_fields = _get_sermon_display_fields(r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10])
     return {
         'date': r[1],
         'notes': r[0] if r[0] else '',
@@ -715,7 +715,7 @@ def worship_list(id=None):
             select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
                    case when t.name then t.name else t.name_2 end,
                    (select i.name from instrument i where i.id = it.instrument_id),
-                   w.title, w.scheduled_date, w.worship_id, s.outline, w.notes, s.is_joint
+                   w.title, w.scheduled_date, w.worship_id, s.outline_en, s.outline_zh, w.notes, s.is_joint
             from worship w
             inner join sermon s on w.scheduled_date = s.date
             left join instrument_team it on w.worship_id = it.worship_id
@@ -729,7 +729,7 @@ def worship_list(id=None):
             select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
                    case when t.name then t.name else t.name_2 end,
                    (select i.name from instrument i where i.id = it.instrument_id),
-                   w.title, w.scheduled_date, w.worship_id, s.outline, w.notes, s.is_joint
+                   w.title, w.scheduled_date, w.worship_id, s.outline_en, s.outline_zh, w.notes, s.is_joint
             from worship w
             inner join sermon s on w.scheduled_date = s.date
             left join instrument_team it on w.worship_id = it.worship_id
@@ -743,22 +743,20 @@ def worship_list(id=None):
         if a and (r[6] or r[7]):
             a['content'].append({'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''})
         else:
-            sermon_fields = _get_sermon_display_fields(r[0], r[1], r[2], r[3], r[4], r[5], r[11], r[13])
+            sermon_fields = _get_sermon_display_fields(r[0], r[1], r[2], r[3], r[4], r[5], r[11], r[12], r[14])
             worship.append({
                 'worship_id': r[10],
                 'date': r[9] if r[9] else '',
                 'worship_title': r[8] if r[8] else '',
-                'sermon_title': sermon_fields['title'],
                 'title_en': sermon_fields['title_en'],
                 'title_zh': sermon_fields['title_zh'],
-                'speaker': sermon_fields['speaker'],
                 'speaker_en': sermon_fields['speaker_en'],
                 'speaker_zh': sermon_fields['speaker_zh'],
-                'bible': sermon_fields['bible'],
                 'bible_en': sermon_fields['bible_en'],
                 'bible_zh': sermon_fields['bible_zh'],
-                'outline': sermon_fields['outline'],
-                'notes': r[12] if r[12] else '',
+                'outline_en': sermon_fields['outline_en'],
+                'outline_zh': sermon_fields['outline_zh'],
+                'notes': r[13] if r[13] else '',
                 'is_joint': sermon_fields['is_joint'],
                 'content': [{'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''}]
             })

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 import sqlite3
+from dataclasses import dataclass
 from datetime import date, datetime
 from time import strftime
 
@@ -7,6 +8,11 @@ import json
 import os
 import re
 #import opencc
+try:
+    import hanzidentifier
+except ImportError:  # pragma: no cover - optional dependency
+    hanzidentifier = None
+
 from app import db as dB
 from app import parser as Parser
 
@@ -69,7 +75,7 @@ def bible_book():
     return content.json()
 
 def search_bible(keyword, offset, range=None):
-    if hanzidentifier.has_chinese(keyword):
+    if hanzidentifier is not None and hanzidentifier.has_chinese(keyword):
         version = conf["bibleAPI"]["version"]["zh"][0]["key"]
     else:
         version = conf["bibleAPI"]["version"]["en"][0]["key"]
@@ -617,67 +623,141 @@ def edit_songset(id, content):
     
     return True
 
+@dataclass
+class SermonVariant:
+    lang: str
+    title: str = ''
+    speaker: str = ''
+    bible: str = ''
+    outline: str = ''
+    is_joint: bool = False
+
+    def to_dict(self):
+        return {
+            'lang': self.lang,
+            'title': self.title,
+            'speaker': self.speaker,
+            'bible': self.bible,
+            'outline': self.outline,
+            'is_joint': self.is_joint,
+        }
+
+
+def _normalize_sermon_lang(lang):
+    if not lang:
+        return 'zh'
+    lang = str(lang).strip().lower()
+    if lang.startswith('zh-tw') or lang.startswith('zh_tw') or lang in {'tw', 'taiwan', 'taiwanese'}:
+        return 'zh-TW'
+    if lang.startswith('zh'):
+        return 'zh'
+    if lang.startswith('en'):
+        return 'en'
+    return 'zh'
+
+
+def _get_sermon_variants_for_date(date):
+    rows = dB.run_para('select lang, title, speaker, bible, outline, is_joint from sermon where date = ? order by lang', [date])
+    variants = {lang: SermonVariant(lang=lang) for lang in ['zh', 'zh-TW', 'en']}
+    for row in rows:
+        lang = _normalize_sermon_lang(row[0])
+        variants[lang] = SermonVariant(
+            lang=lang,
+            title=row[1] if row[1] is not None else '',
+            speaker=row[2] if row[2] is not None else '',
+            bible=row[3] if row[3] is not None else '',
+            outline=row[4] if row[4] is not None else '',
+            is_joint=bool(row[5]) if row[5] is not None else False,
+        )
+
+    return variants
+
+
+def _get_preferred_sermon_variant(variants):
+    for lang in ['zh', 'zh-TW', 'en']:
+        variant = variants.get(lang)
+        if variant and any((variant.title or '').strip() or (variant.speaker or '').strip() or (variant.bible or '').strip() or (variant.outline or '').strip() for _ in [0]):
+            return variant
+    return variants.get('zh') or variants.get('zh-TW') or variants.get('en') or SermonVariant(lang='zh')
+
+
+def _has_sermon_content(variant):
+    return bool((variant.title or '').strip() or (variant.speaker or '').strip() or (variant.bible or '').strip() or (variant.outline or '').strip())
+
+
+def _build_display_order(variants):
+    preferred_order = ['zh', 'zh-TW', 'en']
+    active_langs = [lang for lang in preferred_order if _has_sermon_content(variants.get(lang))]
+    if not active_langs:
+        return ['zh', 'en']
+    if 'zh' not in active_langs and 'en' in active_langs:
+        active_langs = ['zh'] + [lang for lang in active_langs if lang != 'zh']
+    return [lang for lang in active_langs if lang in preferred_order]
+
+
+def _build_sermon_payload(date, notes, variants):
+    preferred_variant = _get_preferred_sermon_variant(variants)
+    payload = {
+        'date': date,
+        'notes': notes or '',
+        'sermons': {lang: variant.to_dict() for lang, variant in variants.items()},
+        'is_joint': any(variant.is_joint for variant in variants.values()),
+        'display_lang': preferred_variant.lang,
+        'display_order': _build_display_order(variants),
+    }
+    return payload
+
+
 def update_sermon(data):
     w_date = data["date"]
-    w_notes = data["notes"] if "notes" in data else None
+    w_notes = data.get("notes")
+    sermons_payload = data.get('sermons') or {}
+    is_joint = int(bool(data.get('is_joint', 0)))
+    display_order = data.get('display_order') or []
 
-    fields = {}
-    for key, val in data.items():
-        if key in ['notes', 'date']:
-            continue
-        if key in ['title_en', 'title_zh', 'speaker_en', 'speaker_zh', 'verse_en', 'verse_zh', 'outline_en', 'outline_zh', 'is_joint']:
-            fields[key] = val
-        elif key in ['title', 'speaker', 'bible_verse', 'outline']:
-            if key == 'title':
-                fields['title_en'] = val
-                fields['title_zh'] = val
-            elif key == 'speaker':
-                fields['speaker_en'] = val
-                fields['speaker_zh'] = val
-            elif key == 'bible_verse':
-                fields['verse_en'] = val
-                fields['verse_zh'] = val
-            elif key == 'outline':
-                fields['outline_zh'] = val
+    existing_rows = dB.run_para('select id, sermon_id, lang from sermon where date = ?', [w_date])
+    existing_by_lang = {_normalize_sermon_lang(r[2]): r[0] for r in existing_rows}
+    parent_ids = {_normalize_sermon_lang(r[2]): r[1] for r in existing_rows}
 
-    if fields:
-        assignments = ', '.join([f"{k} = ?" for k in fields.keys()])
-        values = list(fields.values()) + [w_date]
-        dB.run_para(f"update sermon set {assignments} where date = ?", values)
+    active_langs = []
+    for lang in display_order:
+        if lang in ['zh', 'zh-TW', 'en']:
+            active_langs.append(lang)
+    for lang in ['zh', 'zh-TW', 'en']:
+        if sermons_payload.get(lang):
+            active_langs.append(lang)
+    active_langs = list(dict.fromkeys(active_langs or ['zh', 'en']))
+
+    for lang in active_langs:
+        variant = sermons_payload.get(lang) or {}
+        title = variant.get('title', data.get(f'title_{lang.replace("-", "_")}', data.get('title', '')))
+        speaker = variant.get('speaker', data.get(f'speaker_{lang.replace("-", "_")}', data.get('speaker', '')))
+        bible = variant.get('bible', data.get(f'bible_{lang.replace("-", "_")}', data.get(f'verse_{lang.replace("-", "_")}', data.get('bible_verse', ''))))
+        outline = variant.get('outline', data.get(f'outline_{lang.replace("-", "_")}', data.get('outline', '')))
+
+        row_id = existing_by_lang.get(lang)
+        parent_id = parent_ids.get(lang) or parent_ids.get('en') or parent_ids.get('zh') or 0
+        if row_id:
+            dB.run_para('update sermon set title=?, speaker=?, bible=?, outline=?, is_joint=? where id=?', [title, speaker, bible, outline, is_joint, row_id])
+        else:
+            if parent_id == 0:
+                parent_id = 1 + dB.run('select coalesce(max(sermon_id), 0) from sermon')[0][0]
+            dB.run_para('insert into sermon(sermon_id, lang, title, speaker, bible, outline, is_joint, date) values(?, ?, ?, ?, ?, ?, ?, ?)', [parent_id, lang, title, speaker, bible, outline, is_joint, w_date])
+
+    remove_langs = [lang for lang in ['zh', 'zh-TW', 'en'] if lang not in active_langs]
+    if remove_langs:
+        placeholders = ','.join('?' for _ in remove_langs)
+        dB.run_para(f'delete from sermon where date = ? and lang in ({placeholders})', [w_date, *remove_langs])
 
     if w_notes is not None:
-        dB.run_para("update worship set notes=? where scheduled_date=?", [w_notes, w_date])
-
-
-def _get_sermon_display_fields(title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, outline_en, outline_zh, is_joint):
-    return {
-        'title_en': title_en or '',
-        'title_zh': title_zh or '',
-        'speaker_en': speaker_en or '',
-        'speaker_zh': speaker_zh or '',
-        'bible_en': verse_en or '',
-        'bible_zh': verse_zh or '',
-        'outline_en': outline_en or '',
-        'outline_zh': outline_zh or '',
-        'is_joint': bool(is_joint) if is_joint is not None else False
-    }
+        dB.run_para('update worship set notes=? where scheduled_date=?', [w_notes, w_date])
 
 
 def get_worship(id):
-    sql = """
-        select notes, scheduled_date, s.title_en, s.title_zh, s.speaker_en, s.speaker_zh,
-               s.verse_en, s.verse_zh, s.outline_en, s.outline_zh, s.is_joint
-        from worship w
-        inner join sermon s on w.scheduled_date = s.date
-        where worship_id = ?
-    """
+    sql = 'select notes, scheduled_date from worship where worship_id = ?'
     r = dB.run_para(sql, id)[0]
-    sermon_fields = _get_sermon_display_fields(r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10])
-    return {
-        'date': r[1],
-        'notes': r[0] if r[0] else '',
-        **sermon_fields
-    }
+    variants = _get_sermon_variants_for_date(r[1])
+    return _build_sermon_payload(r[1], r[0] if r[0] else '', variants)
 
 def get_worship_date(id):
     sql = "select scheduled_date from worship where worship_id = ?"
@@ -712,12 +792,10 @@ def get_availablity():
 def worship_list(id=None):
     if id:
         sql = """
-            select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
+            select w.title, w.scheduled_date, w.worship_id, w.notes,
                    case when t.name then t.name else t.name_2 end,
-                   (select i.name from instrument i where i.id = it.instrument_id),
-                   w.title, w.scheduled_date, w.worship_id, s.outline_en, s.outline_zh, w.notes, s.is_joint
+                   (select i.name from instrument i where i.id = it.instrument_id)
             from worship w
-            inner join sermon s on w.scheduled_date = s.date
             left join instrument_team it on w.worship_id = it.worship_id
             left join team t on it.user_id = t.user_id
             where w.worship_id=? and it.instrument_id <> -1
@@ -726,12 +804,10 @@ def worship_list(id=None):
         result = dB.run_para(sql, id)
     else:
         sql = """
-            select s.title_en, s.title_zh, s.speaker_en, s.speaker_zh, s.verse_en, s.verse_zh,
+            select w.title, w.scheduled_date, w.worship_id, w.notes,
                    case when t.name then t.name else t.name_2 end,
-                   (select i.name from instrument i where i.id = it.instrument_id),
-                   w.title, w.scheduled_date, w.worship_id, s.outline_en, s.outline_zh, w.notes, s.is_joint
+                   (select i.name from instrument i where i.id = it.instrument_id)
             from worship w
-            inner join sermon s on w.scheduled_date = s.date
             left join instrument_team it on w.worship_id = it.worship_id
             left join team t on it.user_id = t.user_id
             order by w.scheduled_date, it.instrument_id
@@ -739,26 +815,23 @@ def worship_list(id=None):
         result = dB.run(sql)
     worship = []
     for r in result:
-        a = next((x for x in worship if x['date'] == r[9]), None)
-        if a and (r[6] or r[7]):
-            a['content'].append({'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''})
+        date = r[1] if r[1] else ''
+        a = next((x for x in worship if x['date'] == date), None)
+        if a and (r[4] or r[5]):
+            a['content'].append({'user_name': r[4] if r[4] else '', 'role': r[5] if r[5] else ''})
         else:
-            sermon_fields = _get_sermon_display_fields(r[0], r[1], r[2], r[3], r[4], r[5], r[11], r[12], r[14])
+            variants = _get_sermon_variants_for_date(date)
+            sermon_payload = _build_sermon_payload(date, r[3] if r[3] else '', variants)
             worship.append({
-                'worship_id': r[10],
-                'date': r[9] if r[9] else '',
-                'worship_title': r[8] if r[8] else '',
-                'title_en': sermon_fields['title_en'],
-                'title_zh': sermon_fields['title_zh'],
-                'speaker_en': sermon_fields['speaker_en'],
-                'speaker_zh': sermon_fields['speaker_zh'],
-                'bible_en': sermon_fields['bible_en'],
-                'bible_zh': sermon_fields['bible_zh'],
-                'outline_en': sermon_fields['outline_en'],
-                'outline_zh': sermon_fields['outline_zh'],
-                'notes': r[13] if r[13] else '',
-                'is_joint': sermon_fields['is_joint'],
-                'content': [{'user_name': r[6] if r[6] else '', 'role': r[7] if r[7] else ''}]
+                'worship_id': r[2],
+                'date': date,
+                'worship_title': r[0] if r[0] else '',
+                'sermons': sermon_payload['sermons'],
+                'notes': sermon_payload['notes'],
+                'is_joint': sermon_payload['is_joint'],
+                'display_lang': sermon_payload['display_lang'],
+                'display_order': sermon_payload['display_order'],
+                'content': [{'user_name': r[4] if r[4] else '', 'role': r[5] if r[5] else ''}]
             })
     return worship
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -657,20 +657,9 @@ def _normalize_sermon_lang(lang):
 
 
 def _get_sermon_variants_for_date(date):
+    """Maintains backward compatibility for single-date lookups."""
     rows = dB.run_para('select lang, title, speaker, bible, outline, is_joint from sermon where date = ? order by lang', [date])
-    variants = {lang: SermonVariant(lang=lang) for lang in ['zh', 'zh-TW', 'en']}
-    for row in rows:
-        lang = _normalize_sermon_lang(row[0])
-        variants[lang] = SermonVariant(
-            lang=lang,
-            title=row[1] if row[1] is not None else '',
-            speaker=row[2] if row[2] is not None else '',
-            bible=row[3] if row[3] is not None else '',
-            outline=row[4] if row[4] is not None else '',
-            is_joint=bool(row[5]) if row[5] is not None else False,
-        )
-
-    return variants
+    return _build_sermon_variants_from_rows(rows)
 
 
 def _get_preferred_sermon_variant(variants):
@@ -707,6 +696,20 @@ def _build_sermon_payload(date, notes, variants):
     }
     return payload
 
+def _build_sermon_variants_from_rows(rows):
+    """Helper function to build a variants dictionary from raw database rows."""
+    variants = {lang: SermonVariant(lang=lang) for lang in ['zh', 'zh-TW', 'en']}
+    for row in rows:
+        lang = _normalize_sermon_lang(row[0])
+        variants[lang] = SermonVariant(
+            lang=lang,
+            title=row[1] if row[1] is not None else '',
+            speaker=row[2] if row[2] is not None else '',
+            bible=row[3] if row[3] is not None else '',
+            outline=row[4] if row[4] is not None else '',
+            is_joint=bool(row[5]) if row[5] is not None else False,
+        )
+    return variants
 
 def update_sermon(data):
     w_date = data["date"]
@@ -813,6 +816,36 @@ def worship_list(id=None):
             order by w.scheduled_date, it.instrument_id
         """
         result = dB.run(sql)
+
+    # --- N+1 FIX: Bulk fetch all sermons at once ---
+    unique_dates = list(set([r[1] for r in result if r[1]]))
+    bulk_sermons = {}
+    
+    if unique_dates:
+        sermon_rows = []
+        # Chunk into groups of 900 to avoid SQLite limits on max parameters
+        chunk_size = 900
+        for i in range(0, len(unique_dates), chunk_size):
+            chunk = unique_dates[i:i + chunk_size]
+            placeholders = ','.join(['?'] * len(chunk))
+            sermon_sql = f'select date, lang, title, speaker, bible, outline, is_joint from sermon where date in ({placeholders})'
+            sermon_rows.extend(dB.run_para(sermon_sql, chunk))
+
+        # Group raw rows by date in memory
+        grouped_rows = {}
+        for row in sermon_rows:
+            s_date = row[0]
+            if s_date not in grouped_rows:
+                grouped_rows[s_date] = []
+            # Slice the row so it matches what `_build_sermon_variants_from_rows` expects (ignoring the date column)
+            grouped_rows[s_date].append(row[1:])
+
+        # Build variants for all dates
+        for d in unique_dates:
+            bulk_sermons[d] = _build_sermon_variants_from_rows(grouped_rows.get(d, []))
+
+    # --- End N+1 Fix ---
+
     worship = []
     for r in result:
         date = r[1] if r[1] else ''
@@ -820,8 +853,10 @@ def worship_list(id=None):
         if a and (r[4] or r[5]):
             a['content'].append({'user_name': r[4] if r[4] else '', 'role': r[5] if r[5] else ''})
         else:
-            variants = _get_sermon_variants_for_date(date)
+            # Look up the sermons in memory instead of hitting the database
+            variants = bulk_sermons.get(date, _build_sermon_variants_from_rows([]))
             sermon_payload = _build_sermon_payload(date, r[3] if r[3] else '', variants)
+            
             worship.append({
                 'worship_id': r[2],
                 'date': date,

--- a/app/utils.py
+++ b/app/utils.py
@@ -817,7 +817,6 @@ def worship_list(id=None):
         """
         result = dB.run(sql)
 
-    # --- N+1 FIX: Bulk fetch all sermons at once ---
     unique_dates = list(set([r[1] for r in result if r[1]]))
     bulk_sermons = {}
     
@@ -843,8 +842,6 @@ def worship_list(id=None):
         # Build variants for all dates
         for d in unique_dates:
             bulk_sermons[d] = _build_sermon_variants_from_rows(grouped_rows.get(d, []))
-
-    # --- End N+1 Fix ---
 
     worship = []
     for r in result:

--- a/migration.py
+++ b/migration.py
@@ -1,0 +1,91 @@
+import sqlite3
+from pathlib import Path
+
+
+def migrate_sermon_schema(db_path: str | None = None) -> None:
+    db_file = Path(db_path or 'db/worship.db')
+    if not db_file.exists():
+        raise FileNotFoundError(f"Database not found: {db_file}")
+
+    conn = sqlite3.connect(db_file)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    print(f"Migrating {db_file}")
+
+    cols = [row[1] for row in cur.execute('PRAGMA table_info(sermon)')]
+    needed = {
+        'title_en': 'TEXT',
+        'title_zh': 'TEXT',
+        'speaker_en': 'TEXT',
+        'speaker_zh': 'TEXT',
+        'verse_en': 'TEXT',
+        'verse_zh': 'TEXT',
+        'is_joint': 'INTEGER DEFAULT 0',
+    }
+
+    for name, definition in needed.items():
+        if name not in cols:
+            cur.execute(f'ALTER TABLE sermon ADD COLUMN {name} {definition}')
+
+    cur.execute('''
+        UPDATE sermon
+        SET title_en = COALESCE(title_en, title),
+            title_zh = COALESCE(title_zh, title),
+            speaker_en = COALESCE(speaker_en, speaker),
+            speaker_zh = COALESCE(speaker_zh, speaker),
+            verse_en = COALESCE(verse_en, bible_verse),
+            verse_zh = COALESCE(verse_zh, bible_verse)
+        WHERE (title_en IS NULL OR title_en = '')
+           OR (title_zh IS NULL OR title_zh = '')
+           OR (speaker_en IS NULL OR speaker_en = '')
+           OR (speaker_zh IS NULL OR speaker_zh = '')
+           OR (verse_en IS NULL OR verse_en = '')
+           OR (verse_zh IS NULL OR verse_zh = '')
+    ''')
+
+    cur.execute('''
+        SELECT sermon_id, title, speaker, bible_verse, keyword, outline, lang, updated, date,
+               title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, is_joint
+        FROM sermon
+    ''')
+    rows = cur.fetchall()
+
+    cur.execute('DROP TABLE sermon')
+    cur.execute('''
+        CREATE TABLE sermon (
+            sermon_id INTEGER PRIMARY KEY,
+            title_en TEXT,
+            title_zh TEXT,
+            speaker_en TEXT,
+            speaker_zh TEXT,
+            verse_en TEXT,
+            verse_zh TEXT,
+            is_joint INTEGER DEFAULT 0,
+            title TEXT,
+            speaker TEXT,
+            bible_verse TEXT,
+            keyword TEXT,
+            outline TEXT,
+            lang TEXT,
+            updated TEXT DEFAULT CURRENT_TIMESTAMP,
+            date TEXT
+        )
+    ''')
+
+    for row in rows:
+        cur.execute('''
+            INSERT INTO sermon (
+                sermon_id, title, speaker, bible_verse, keyword, outline, lang, updated, date,
+                title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, is_joint
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', tuple(row))
+
+    cur.execute("UPDATE sermon SET title = '', speaker = '', bible_verse = ''")
+    conn.commit()
+    print('Migration complete')
+    conn.close()
+
+
+if __name__ == '__main__':
+    migrate_sermon_schema()

--- a/migration.py
+++ b/migration.py
@@ -2,6 +2,33 @@ import sqlite3
 from pathlib import Path
 
 
+def _normalize_lang(lang: str | None) -> str:
+    if not lang:
+        return 'zh'
+    lang = str(lang).strip().lower()
+    if lang.startswith('zh'):
+        return 'zh'
+    if lang.startswith('en'):
+        return 'en'
+    return 'zh'
+
+
+def _get_default_language(row: sqlite3.Row) -> str:
+    legacy_lang = _normalize_lang(row['lang'])
+    has_values = any(
+        (row['title'] or '').strip() or
+        (row['speaker'] or '').strip() or
+        (row['bible_verse'] or '').strip() or
+        (row['outline'] or '').strip()
+        for _ in [0]
+    )
+    if legacy_lang == 'en':
+        return 'en'
+    if legacy_lang == 'zh':
+        return 'zh'
+    return 'zh' if has_values else 'en'
+
+
 def migrate_sermon_schema(db_path: str | None = None) -> None:
     db_file = Path(db_path or 'db/worship.db')
     if not db_file.exists():
@@ -13,84 +40,62 @@ def migrate_sermon_schema(db_path: str | None = None) -> None:
 
     print(f"Migrating {db_file}")
 
-    cols = [row[1] for row in cur.execute('PRAGMA table_info(sermon)')]
-    needed = {
-        'title_en': 'TEXT',
-        'title_zh': 'TEXT',
-        'speaker_en': 'TEXT',
-        'speaker_zh': 'TEXT',
-        'verse_en': 'TEXT',
-        'verse_zh': 'TEXT',
-        'outline_en': 'TEXT',
-        'outline_zh': 'TEXT',
-        'is_joint': 'INTEGER DEFAULT 0',
-    }
-
-    for name, definition in needed.items():
-        if name not in cols:
-            cur.execute(f'ALTER TABLE sermon ADD COLUMN {name} {definition}')
-
-    cur.execute('''
-        UPDATE sermon
-        SET title_en = COALESCE(title_en, title),
-            title_zh = COALESCE(title_zh, title),
-            speaker_en = COALESCE(speaker_en, speaker),
-            speaker_zh = COALESCE(speaker_zh, speaker),
-            verse_en = COALESCE(verse_en, bible_verse),
-            verse_zh = COALESCE(verse_zh, bible_verse),
-            outline_zh = COALESCE(outline_zh, outline),
-            outline_en = COALESCE(outline_en, '')
-        WHERE (title_en IS NULL OR title_en = '')
-           OR (title_zh IS NULL OR title_zh = '')
-           OR (speaker_en IS NULL OR speaker_en = '')
-           OR (speaker_zh IS NULL OR speaker_zh = '')
-           OR (verse_en IS NULL OR verse_en = '')
-           OR (verse_zh IS NULL OR verse_zh = '')
-           OR (outline_zh IS NULL OR outline_zh = '')
-    ''')
-
+    cur.execute('DROP TABLE IF EXISTS sermon_old')
     cur.execute('ALTER TABLE sermon RENAME TO sermon_old')
+
     cur.execute('''
         CREATE TABLE sermon (
-            sermon_id INTEGER PRIMARY KEY,
-            title_en TEXT,
-            title_zh TEXT,
-            speaker_en TEXT,
-            speaker_zh TEXT,
-            verse_en TEXT,
-            verse_zh TEXT,
-            outline_en TEXT,
-            outline_zh TEXT,
+            id INTEGER PRIMARY KEY,
+            sermon_id INTEGER NOT NULL,
+            lang TEXT NOT NULL,
+            title TEXT,
+            speaker TEXT,
+            bible TEXT,
+            outline TEXT,
             is_joint INTEGER DEFAULT 0,
             keyword TEXT,
-            lang TEXT,
             updated TEXT DEFAULT CURRENT_TIMESTAMP,
             date TEXT
         )
     ''')
 
-    cur.execute('''
-        INSERT INTO sermon (
-            sermon_id, title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh,
-            outline_en, outline_zh, is_joint, keyword, lang, updated, date
-        )
-        SELECT
-            sermon_id,
-            COALESCE(title_en, ''),
-            COALESCE(title_zh, ''),
-            COALESCE(speaker_en, ''),
-            COALESCE(speaker_zh, ''),
-            COALESCE(verse_en, ''),
-            COALESCE(verse_zh, ''),
-            COALESCE(outline_en, ''),
-            COALESCE(outline_zh, ''),
-            COALESCE(is_joint, 0),
-            keyword,
-            lang,
-            updated,
-            date
+    rows = cur.execute('''
+        SELECT sermon_id, title, speaker, bible_verse, keyword, outline, lang, updated, date
         FROM sermon_old
-    ''')
+    ''').fetchall()
+
+    for row in rows:
+        sermon_id = row['sermon_id']
+        populated_lang = _get_default_language(row)
+
+        for target_lang in ['en', 'zh']:
+            if target_lang == populated_lang:
+                title = row['title'] or ''
+                speaker = row['speaker'] or ''
+                bible = row['bible_verse'] or ''
+                outline = row['outline'] or ''
+            else:
+                title = ''
+                speaker = ''
+                bible = ''
+                outline = ''
+
+            cur.execute('''
+                INSERT INTO sermon (
+                    sermon_id, lang, title, speaker, bible, outline, is_joint, keyword, updated, date
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                sermon_id,
+                target_lang,
+                title,
+                speaker,
+                bible,
+                outline,
+                0,
+                row['keyword'] or '',
+                row['updated'] or '',
+                row['date'] or '',
+            ))
 
     cur.execute('DROP TABLE sermon_old')
     conn.commit()

--- a/migration.py
+++ b/migration.py
@@ -21,6 +21,8 @@ def migrate_sermon_schema(db_path: str | None = None) -> None:
         'speaker_zh': 'TEXT',
         'verse_en': 'TEXT',
         'verse_zh': 'TEXT',
+        'outline_en': 'TEXT',
+        'outline_zh': 'TEXT',
         'is_joint': 'INTEGER DEFAULT 0',
     }
 
@@ -35,23 +37,19 @@ def migrate_sermon_schema(db_path: str | None = None) -> None:
             speaker_en = COALESCE(speaker_en, speaker),
             speaker_zh = COALESCE(speaker_zh, speaker),
             verse_en = COALESCE(verse_en, bible_verse),
-            verse_zh = COALESCE(verse_zh, bible_verse)
+            verse_zh = COALESCE(verse_zh, bible_verse),
+            outline_zh = COALESCE(outline_zh, outline),
+            outline_en = COALESCE(outline_en, '')
         WHERE (title_en IS NULL OR title_en = '')
            OR (title_zh IS NULL OR title_zh = '')
            OR (speaker_en IS NULL OR speaker_en = '')
            OR (speaker_zh IS NULL OR speaker_zh = '')
            OR (verse_en IS NULL OR verse_en = '')
            OR (verse_zh IS NULL OR verse_zh = '')
+           OR (outline_zh IS NULL OR outline_zh = '')
     ''')
 
-    cur.execute('''
-        SELECT sermon_id, title, speaker, bible_verse, keyword, outline, lang, updated, date,
-               title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, is_joint
-        FROM sermon
-    ''')
-    rows = cur.fetchall()
-
-    cur.execute('DROP TABLE sermon')
+    cur.execute('ALTER TABLE sermon RENAME TO sermon_old')
     cur.execute('''
         CREATE TABLE sermon (
             sermon_id INTEGER PRIMARY KEY,
@@ -61,27 +59,40 @@ def migrate_sermon_schema(db_path: str | None = None) -> None:
             speaker_zh TEXT,
             verse_en TEXT,
             verse_zh TEXT,
+            outline_en TEXT,
+            outline_zh TEXT,
             is_joint INTEGER DEFAULT 0,
-            title TEXT,
-            speaker TEXT,
-            bible_verse TEXT,
             keyword TEXT,
-            outline TEXT,
             lang TEXT,
             updated TEXT DEFAULT CURRENT_TIMESTAMP,
             date TEXT
         )
     ''')
 
-    for row in rows:
-        cur.execute('''
-            INSERT INTO sermon (
-                sermon_id, title, speaker, bible_verse, keyword, outline, lang, updated, date,
-                title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh, is_joint
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ''', tuple(row))
+    cur.execute('''
+        INSERT INTO sermon (
+            sermon_id, title_en, title_zh, speaker_en, speaker_zh, verse_en, verse_zh,
+            outline_en, outline_zh, is_joint, keyword, lang, updated, date
+        )
+        SELECT
+            sermon_id,
+            COALESCE(title_en, ''),
+            COALESCE(title_zh, ''),
+            COALESCE(speaker_en, ''),
+            COALESCE(speaker_zh, ''),
+            COALESCE(verse_en, ''),
+            COALESCE(verse_zh, ''),
+            COALESCE(outline_en, ''),
+            COALESCE(outline_zh, ''),
+            COALESCE(is_joint, 0),
+            keyword,
+            lang,
+            updated,
+            date
+        FROM sermon_old
+    ''')
 
-    cur.execute("UPDATE sermon SET title = '', speaker = '', bible_verse = ''")
+    cur.execute('DROP TABLE sermon_old')
     conn.commit()
     print('Migration complete')
     conn.close()

--- a/web/index.py
+++ b/web/index.py
@@ -186,8 +186,6 @@ def get_weekly_sheets(id):
 
     return render_template('worship/sheets.html', sheets=sheets)
 
-
-
 @app.route("/worship/schedule")
 def schedule():
 	now = datetime.now()
@@ -321,10 +319,6 @@ def assets():
 
 	return render_template('slides_assets.html', setting=setting, assets=assets, promote=promote)
 
-# @app.route("/people")
-# def people():
-# 	people = Utils.get_teams()
-# 	return render_template('people.html', people=people)
 
 # -------- Slides Pages ---------
 
@@ -411,7 +405,6 @@ def admin_calendar():
 def admin_report(id):
 	report, saved = Tools.get_report(id)
 	return render_template('admin/report_pdf.html', saved=saved, report=report, id=id)
-
 
 # --------- Other Pages ---------
 @app.route("/files")

--- a/web/static/css/worship-shared.css
+++ b/web/static/css/worship-shared.css
@@ -1,0 +1,137 @@
+/* =========================================
+   Shared App Containers
+   ========================================= */
+.app-card {
+    background: #fdfdfd;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.04);
+    margin: 15px auto;
+    box-sizing: border-box;
+}
+
+.action_btn_container {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 1rem; /* Added to accommodate notes.html spacing */
+}
+
+/* =========================================
+   Sermon Box
+   ========================================= */
+.sermon-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 8px;
+    margin-bottom: 12px;
+}
+.sermon-title { margin: 0; font-size: 1.3em; color: #2c3e50; }
+.sermon-speaker { font-weight: 600; color: #7f8c8d; background: #eaeded; padding: 4px 8px; border-radius: 4px; font-size: 0.9em;}
+.sermon-bible { font-size: 1.05em; margin-bottom: 12px; }
+.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; margin-bottom: 12px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
+
+.bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }
+.bible-link:hover { background: #009698; color: #fff; }
+
+/* =========================================
+   Language Tags
+   ========================================= */
+.lang_en    { --lang-color: #009698; }
+.lang_zh    { --lang-color: #8b0000; }
+.lang_zhTW  { --lang-color: #556b2f; }
+.lang_zhpingyin { --lang-color: #856088; }
+
+.lang_en, .lang_zh, .lang_zhTW, .lang_zhpingyin {
+    border-radius: 50px 20px;
+    color: #fff;
+    border: 4px solid var(--lang-color);
+    background-color: var(--lang-color);
+}
+
+/* =========================================
+   Media Icons Container & Dropdowns
+   ========================================= */
+.media-icons-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: inherit; /* Pulls from parent flexbox */
+    vertical-align: middle;
+}
+
+.media-icons-wrapper > a,
+.media-icons-wrapper > .media-dropdown {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    text-decoration: none;
+    line-height: 1;
+}
+
+.media-icons-wrapper i {
+    font-size: 22px !important;
+    line-height: 1 !important;
+}
+
+.media-dropbtn {
+    cursor: pointer;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #333;
+    padding-right: 6px; 
+}
+
+.media-dropbtn .badge {
+    background-color: #dc3545;
+    color: white;
+    border-radius: 10px;
+    padding: 1px 5px;
+    font-size: 10px;
+    position: absolute;
+    top: -4px;        
+    right: -2px;      
+    font-weight: bold;
+    line-height: 1;
+    box-shadow: 0 0 0 2px #ffffff;
+    z-index: 2;
+}
+
+.media-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #fff;
+    min-width: 110px;
+    box-shadow: 0px 4px 12px rgba(0,0,0,0.15);
+    z-index: 100;
+    border-radius: 5px;
+    border: 1px solid #eee;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 5px 0;
+}
+
+.media-dropdown-content a {
+    color: #333;
+    padding: 8px 15px;
+    text-decoration: none;
+    display: block;
+    font-size: 13px;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.media-dropdown-content a:hover {
+    background-color: #f5f5f5;
+    color: #009698;
+}
+
+.media-dropdown:hover .media-dropdown-content {
+    display: block;
+}

--- a/web/static/presentation.js
+++ b/web/static/presentation.js
@@ -263,6 +263,7 @@
 			                o_fragment = origin_.splice(0, fragment).join('<br/>')
 			                r_fragment = region_.splice(0, fragment).join('<br/>')
 				            let sub_section = document.createElement('section');
+                            sub_section.classList.add('top-align');
 				            sub_section.append(create_view(data.type, o_fragment, r_fragment, s_name));
       			            sub_section.setAttribute('order', j);
       			            section.append(sub_section);

--- a/web/static/presentation.js
+++ b/web/static/presentation.js
@@ -87,10 +87,14 @@
     }
 
     function move_top(para) {
-        scrollTo = $('div[class="inner present"]');
-        base = $('.preview').offset().top;
-        $('.preview').scrollTop(base);
-        $('.preview').scrollTop($(scrollTo).offset().top - base);
+        let scrollTo = $('div.inner.present'); 
+        let preview = $('.preview');
+
+        if (scrollTo.length > 0 && preview.length > 0) {
+            let base = preview.offset().top;
+            preview.scrollTop(base);
+            preview.scrollTop(scrollTo.offset().top - base);
+        }
     }
 
     function save_slides() {

--- a/web/static/worship.js
+++ b/web/static/worship.js
@@ -44,25 +44,9 @@ var API_URL = '/API/';
                 html += '<div class="song-details-row">';
                 html += '<span>Current Key: <select class="key" name="' + data.transpose + '" init="' + data.song_key + '"><option>' + data.song_key + '</option></select></span>';
                 html += '<span>&nbsp;Original Key: ' + data.song_key + '</span>';
-                
-                // This forEach stuff could be removed if we decided to make every sheet redirect 
-                // to the sheets page as opposed to the specific link of the sheet page.
-                if (data.score && data.score.length > 0) {
-                    data.score.forEach(function(link) {
-                        html += '<a href="' + link + '" target="new"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>';
-                    });
-                }
-                if (data.abc && data.abc.length > 0) {
-                    // For interacted sheets, we just need the route to the ID. One icon is sufficient.
-                    html += '<a href="/worship/sheets/' + data.id + '" target="new"><i class="fa" style="font-size:24px" title="Interacted Sheet Music">&#xf1c7;</i></a>';
-                }
-                if (data.video && data.video.length > 0) {
-                    data.video.forEach(function(link) {
-                        html += '<a href="' + link + '" target="new"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>';
-                    });
-                }
+                html += get_links(data.video, data.score, data.abc, data.id);
                 html += '</div>';
-
+                
                 // Row 3: Notes
                 html += '<div class="song-notes-row">';
                 html += '<p>Notes: <textarea name="song_notes" index="' + index + '" rows="5" cols="60">' + data.notes + '</textarea></p>';
@@ -442,21 +426,37 @@ var API_URL = '/API/';
 
     // Return media links
     function get_links(video, score, abc, id) {
-        var links = '';
-        
-        if (Array.isArray(video) && video.length > 0) {
-            video.forEach(v => links += "<a href='" + v + "' target='new'><i class='fa fa-play-circle' style='font-size:24px' title='Youtube Video'></i></a>");
-        }
-        
+        let html = '';
+
         if (Array.isArray(score) && score.length > 0) {
-            score.forEach(s => links += "<a href='" + s + "' target='new'><i style='font-size:24px' class='fa' title='Sheet Music'>&#xf0f6;</i></a>");
+            if (score.length === 1) {
+                html += `<a href="${score[0]}" target="_blank"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>`;
+            } else {
+                html += `<div class="media-dropdown">
+                    <span class="media-dropbtn"><i class="fa" style="font-size:24px" title="Sheet Music">&#xf0f6;</i><span class="badge">${score.length}</span></span>
+                    <div class="media-dropdown-content">`;
+                score.forEach((link, idx) => { html += `<a href="${link}" target="_blank">Sheet Music ${idx + 1}</a>`; });
+                html += `</div></div>`;
+            }
         }
-        
+
         if (Array.isArray(abc) && abc.length > 0 && id) {
-            links += "<a href='/worship/sheets/" + id + "' target='new'><i style='font-size:24px' class='fa' title='Interacted Sheet Music'>&#xf1c7;</i></a>";
+            html += `<a href="/worship/sheets/${id}" target="_blank"><i style="font-size:24px" class="fa" title="Interactive Sheet Music">&#xf1c7;</i></a>`;
+        }
+
+        if (Array.isArray(video) && video.length > 0) {
+            if (video.length === 1) {
+                html += `<a href="${video[0]}" target="_blank"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>`;
+            } else {
+                html += `<div class="media-dropdown">
+                    <span class="media-dropbtn"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Videos"></i><span class="badge">${video.length}</span></span>
+                    <div class="media-dropdown-content">`;
+                video.forEach((link, idx) => { html += `<a href="${link}" target="_blank">Video ${idx + 1}</a>`; });
+                html += `</div></div>`;
+            }
         }
         
-        return links;
+        return html ? `<span class="media-icons-wrapper">${html}</span>` : '';
     }
 
     // Highlighted search keyword in the song title

--- a/web/static/worship.js
+++ b/web/static/worship.js
@@ -16,19 +16,14 @@ var API_URL = '/API/';
         }, 'slow');
     }
     
-    // UI for Adding song to song_set
-    function add_song_to_worship(worship_list) {
-        worship_list.empty();
-        var top_ul = document.createElement('ul');
-        top_ul.setAttribute('id', 'songs');
-        var i = 0;
-        for (data of songs_temp) {
-            var list = document.createElement('li');
-            list.setAttribute('class', 'ui-state-default');
-            list.setAttribute('name', data.id);
+    // New helper function to build a single song <li>
+    function generate_song_card(data, index) {
+        var list = document.createElement('li');
+        list.setAttribute('class', 'ui-state-default');
+        list.setAttribute('name', data.id);
 
-            if (data.type == 'song') {
-                var html = '<div class="song-content-wrapper">';
+        if (data.type == 'song') {
+            var html = '<div class="song-content-wrapper">';
 
                 // Row 1: Title, Metadata, Delete Button
                 html += '<div class="song-header-row">';
@@ -50,20 +45,27 @@ var API_URL = '/API/';
                 html += '<span>Current Key: <select class="key" name="' + data.transpose + '" init="' + data.song_key + '"><option>' + data.song_key + '</option></select></span>';
                 html += '<span>&nbsp;Original Key: ' + data.song_key + '</span>';
                 
-                if (data.score) {
-                    html += '<a href="' + data.score + '" target="new"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>';
+                // This forEach stuff could be removed if we decided to make every sheet redirect 
+                // to the sheets page as opposed to the specific link of the sheet page.
+                if (data.score && data.score.length > 0) {
+                    data.score.forEach(function(link) {
+                        html += '<a href="' + link + '" target="new"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>';
+                    });
                 }
-                if (data.abc.length > 0) {
+                if (data.abc && data.abc.length > 0) {
+                    // For interacted sheets, we just need the route to the ID. One icon is sufficient.
                     html += '<a href="/worship/sheets/' + data.id + '" target="new"><i class="fa" style="font-size:24px" title="Interacted Sheet Music">&#xf1c7;</i></a>';
                 }
-                if (data.video) {
-                    html += '<a href="' + data.video + '" target="new"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>';
+                if (data.video && data.video.length > 0) {
+                    data.video.forEach(function(link) {
+                        html += '<a href="' + link + '" target="new"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>';
+                    });
                 }
                 html += '</div>';
 
                 // Row 3: Notes
                 html += '<div class="song-notes-row">';
-                html += '<p>Notes: <textarea name="song_notes" index="' + i + '" rows="5" cols="60">' + data.notes + '</textarea></p>';
+                html += '<p>Notes: <textarea name="song_notes" index="' + index + '" rows="5" cols="60">' + data.notes + '</textarea></p>';
                 html += '</div>';
 
                 // Row 4: Sequence Container
@@ -110,11 +112,25 @@ var API_URL = '/API/';
                 
                 var sequenceContainer = list.querySelector('.sequence-container');
                 sequenceContainer.appendChild(ul);
-            }
-            else if (data.type == 'info') {
-                list.innerHTML = '<span class="infotitle" name="' + data.id + '" bible="' + data.bible + '">' + data.notes + '&nbsp;<button class="remove_btn" style="display:none"> - </button></span>';
-            }
-            top_ul.append(list)
+            
+            var sequenceContainer = list.querySelector('.sequence-container');
+            sequenceContainer.appendChild(ul);
+        }
+        else if (data.type == 'info') {
+            list.innerHTML = '<span class="infotitle" name="' + data.id + '" bible="' + data.bible + '">' + data.notes + '&nbsp;<button class="remove_btn" style="display:none"> - </button></span>';
+        }
+        
+        return list;
+    }
+
+    function add_song_to_worship(worship_list) {
+        worship_list.empty();
+        var top_ul = document.createElement('ul');
+        top_ul.setAttribute('id', 'songs');
+        var i = 0;
+        for (data of songs_temp) {
+            var list = generate_song_card(data, i);
+            top_ul.append(list);
             i++;
         }
         worship_list.append(top_ul);
@@ -315,11 +331,54 @@ var API_URL = '/API/';
                             console.log('tempSubmit', tempSubmit);
                             if (num == 0) {   // When popup is for edit
                                 var click_url = API_URL + 'song/' + id;
-                                submit_song(click_url, JSON.stringify(tempSubmit)).done(function(response) {
-                                    console.log(response);
-                                });
-                                $("#dialog").dialog("close");
-                                location.reload();
+                                
+                                // Helper function for the refresh logic
+                                function updateCardAfterSave() {
+                                    $("#dialog").dialog("close");
+
+                                    // Fetch the newly saved song data from database
+                                    get_song(id).done(function(updated_song_data) {
+                                        
+                                        let songIndex = songs_temp.findIndex(s => s.id == id);
+                                        
+                                        if (songIndex > -1) {
+                                            let old_song = songs_temp[songIndex];
+                                            
+                                            // Preserve the worship-specific data
+                                            updated_song_data.transpose = old_song.transpose;
+                                            updated_song_data.notes = old_song.notes;
+                                            updated_song_data.alt_sequence = old_song.alt_sequence;
+                                            updated_song_data.date = old_song.date;
+
+                                            // Update songs_temp
+                                            songs_temp[songIndex] = updated_song_data;
+
+                                            // Generate the HTML for JUST this specific card
+                                            let new_card_html = generate_song_card(updated_song_data, songIndex);
+                                            
+                                            $('#worship li[name="' + id + '"]').replaceWith(new_card_html);
+
+                                            init();
+                                        }
+                                    });
+                                }
+
+                                submit_song(click_url, JSON.stringify(tempSubmit))
+                                    .done(function(response) {
+                                        console.log("Saved successfully with JSON response:", response);
+                                        updateCardAfterSave();
+                                    })
+                                    .fail(function(jqXHR, textStatus, errorThrown) {
+                                        // Check if it actually succeeded but just failed the JSON parse
+                                        if (jqXHR.status === 200) {
+                                            console.log("Saved successfully (plain text response).");
+                                            updateCardAfterSave();
+                                        } else {
+                                            console.error("AJAX Error:", textStatus, errorThrown);
+                                            alert("Failed to save changes. Please try again.");
+                                        }
+                                    });
+                                    
                                 return false;
                             }
 
@@ -382,11 +441,21 @@ var API_URL = '/API/';
     }
 
     // Return media links
-    function get_links(video, score, id) {
+    function get_links(video, score, abc, id) {
         var links = '';
-        links += video ? "<a href='" + video + "' target='new'><i class='fa fa-play-circle' style='font-size:24px' title='Youtube Video'></i></a>" : "";
-        links += score ? "<a href='" + score + "' target='new'><i style='font-size:24px' class='fa' title='Sheet Music'>&#xf0f6;</i></a>" : "";
-        links += id? "<a href='/worship/sheets/" + id + "' target='new'><i style='font-size:24px' class='fa' title='Interacted Sheet Music'>&#xf1c7;</i></a>" : "";
+        
+        if (Array.isArray(video) && video.length > 0) {
+            video.forEach(v => links += "<a href='" + v + "' target='new'><i class='fa fa-play-circle' style='font-size:24px' title='Youtube Video'></i></a>");
+        }
+        
+        if (Array.isArray(score) && score.length > 0) {
+            score.forEach(s => links += "<a href='" + s + "' target='new'><i style='font-size:24px' class='fa' title='Sheet Music'>&#xf0f6;</i></a>");
+        }
+        
+        if (Array.isArray(abc) && abc.length > 0 && id) {
+            links += "<a href='/worship/sheets/" + id + "' target='new'><i style='font-size:24px' class='fa' title='Interacted Sheet Music'>&#xf1c7;</i></a>";
+        }
+        
         return links;
     }
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -23,7 +23,8 @@
 
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    
     <!-- Page-Specific Styles -->
     {% block extra_css %}{% endblock %}
 </head>

--- a/web/templates/slides/slides_view.html
+++ b/web/templates/slides/slides_view.html
@@ -32,6 +32,12 @@
         #top-right    { top: 0; right: 0; }
         #bottom-left  { bottom: 0; left: 0; }
         #bottom-right { bottom: 0; right: 0; }
+
+        /* Create a custom class to force a slide to the top */
+        .reveal .slides section.top-align {
+            top: 0 !important;
+            padding-top: 20px;
+        }
     </style>
     <script>
 

--- a/web/templates/worship/chords.html
+++ b/web/templates/worship/chords.html
@@ -3,7 +3,7 @@
 {% block page_title %}Worship Chords{% endblock %}
 
 {% block extra_css %}
-<link href="../static/presentation.css" rel="stylesheet">
+<link href="/static/presentation.css" rel="stylesheet">
 <style>
   span.chunk {
     position: relative;

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -4,18 +4,14 @@
 
 {% block extra_css %}
 <meta name="viewport" content="width=device-width, initial-scale=1" charset="utf-8">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="/static/css/worship-shared.css">
 <style>
-.summary_container{
+.reference {
+    padding: 0.5em;
     display: flex;
-    flex-direction: column;
-    background: #fdfdfd;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 15px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.04);
-    margin: 15px auto;
-    box-sizing: border-box;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
 }
 
 span.chunk {
@@ -29,9 +25,6 @@ span.chunk:before {
     top:-2em;
 }
 
-.reference {
-    padding: 0.5em;
-}
 .song_chord {
     line-height: 200%;
 }
@@ -50,15 +43,15 @@ span.chunk:before {
     color: #000;
 }
 
-.notes {
-    text-align: center;
-    flex: 1; /* Takes up the remaining 50% width */
-}
-
 .song_block > span {
     position: absolute;
     top: 5px;
     left: 5px;
+}
+
+.notes {
+    text-align: center;
+    flex: 1;
 }
 
 .info {
@@ -72,23 +65,6 @@ span.chunk:before {
     color: #000;
     border-radius: 5px;
     padding: 0px 10px 10px 10px;
-}
-
-.notes {
-    text-align: center;
-}
-
-/* Language tags */
-.lang_en    { --lang-color: #009698; }
-.lang_zh    { --lang-color: #8b0000; }
-.lang_zhTW  { --lang-color: #556b2f; }
-.lang_zhpingyin { --lang-color: #856088; }
-
-.lang_en, .lang_zh, .lang_zhTW, .lang_zhpingyin {
-    border-radius: 50px 20px;
-    color: #fff;
-    border: 4px solid var(--lang-color);
-    background-color: var(--lang-color);
 }
 
 /* Toggle buttons */
@@ -109,17 +85,18 @@ span.chunk:before {
     color: white;
 }
 
-.worship_controls_button_container {
+/* Video Grid */
+.video-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 1rem;
+    gap: 20px;
+    justify-content: center;
+    margin-bottom: 30px;
 }
 
-/* Cotainer for Video (helps scale) */
 .video-container {
-    width: 100%;
-    max-width: 640px;
+    flex: 1 1 400px; 
+    max-width: 640px; 
     aspect-ratio: 16 / 9;
 }
 
@@ -128,144 +105,17 @@ span.chunk:before {
     height: 100%;
 }
 
-/* Sermon Box */
-#summary_container h3 {
-    margin-top: 0;
-}
-.sermon-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 2px solid #eee;
-    padding-bottom: 8px;
-    margin-bottom: 12px;
-}
-.sermon-title { margin: 0; font-size: 1.3em; color: #2c3e50; }
-.sermon-speaker { font-weight: 600; color: #7f8c8d; background: #eaeded; padding: 4px 8px; border-radius: 4px; font-size: 0.9em;}
-.sermon-bible { font-size: 1.05em; margin-bottom: 12px; }
-.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; margin-bottom: 12px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
-
-/* Bible Link */
-.bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }
-.bible-link:hover { background: #009698; color: #fff; }
-
-/* =========================================
-   Media Icons Container & Dropdown Styling
-   ========================================= */
-.media-icons-wrapper {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    margin-left: 12px;
-    vertical-align: middle;
-}
-
-/* Force both single <a> links and .media-dropdown wrappers to share identical alignment */
-.media-icons-wrapper > a,
-.media-icons-wrapper > .media-dropdown {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    text-decoration: none;
-    line-height: 1;
-}
-
-/* Ensure all font icons render at an identical size and vertical height */
-.media-icons-wrapper i {
-    font-size: 22px !important;
-    line-height: 1 !important;
-}
-
-/* Container for the icon + badge */
-.media-dropbtn {
-    cursor: pointer;
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    color: #333;
-    padding-right: 6px; /* Reserves layout space so the badge doesn't hit the next icon */
-}
-
-/* Badge pinned neatly to the top-right corner of the icon */
-.media-dropbtn .badge {
-    background-color: #dc3545;
-    color: white;
-    border-radius: 10px;
-    padding: 1px 5px;
-    font-size: 10px;
-    position: absolute;
-    top: -4px;
-    right: -2px;
-    font-weight: bold;
-    line-height: 1;
-    box-shadow: 0 0 0 2px #ffffff;
-    z-index: 2;
-}
-
-.media-dropdown-content {
-    display: none;
-    position: absolute;
-    background-color: #fff;
-    min-width: 110px;
-    box-shadow: 0px 4px 12px rgba(0,0,0,0.15);
-    z-index: 100;
-    border-radius: 5px;
-    border: 1px solid #eee;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 5px 0;
-}
-
-.media-dropdown-content a {
-    color: #333;
-    padding: 8px 15px;
-    text-decoration: none;
-    display: block;
-    font-size: 13px;
-    text-align: left;
-    white-space: nowrap;
-}
-
-.media-dropdown-content a:hover {
-    background-color: #f5f5f5;
-    color: #009698;
-}
-
-.media-dropdown:hover .media-dropdown-content {
-    display: block;
-}
-
-/* =========================================
-   Video Grid
-   ========================================= */
-.video-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    justify-content: center; /* Centers the videos if there's an odd number */
-    margin-bottom: 30px;
-}
-
-/* Update your existing .video-container to work within the grid */
-.video-container {
-    flex: 1 1 400px; /* Try to be 400px wide, but shrink on mobile screens */
-    max-width: 640px; 
-    aspect-ratio: 16 / 9;
-}
-
 </style>
 {% endblock %}
 
 {% block content %}
 
-    <div id="summary_container" class="summary_container">
+    <div id="summary_container" class="app-card">
         <!-- Dynamically populated by get_sermon() -->
     </div>
     
     <!-- Container of worship songs -->
-    <div class="worship_controls_button_container">
+    <div class="action_btn_container">
         <button class="toggle-btn view" onclick="loadTab('view')">View</button>
         <button class="toggle-btn chord" onclick="loadTab('chord')">Chord</button>
         <button class="toggle-btn bi" onclick="loadTab('bi')">Bilingual</button>

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -134,22 +134,21 @@ span.chunk:before {
 
     <div id="summary_container" class="summary_container">
         <h3>{{ w.date }} 敬拜筆記 (Worship Notes)</h3>
-
-        <div class="card-row">
-            <p>
-                <b>English</b><br/>
-                <b>Title:</b> {{ w.title_en or '' }}<br/>
-                <b>Speaker:</b> {{ w.speaker_en or '' }}<br/>
-                <b>Bible:</b> <span id="bible_verse_en">{{ w.bible_en or '' }}</span><br/>
-                <b>Outline:</b> {{ w.outline_en or '' }}<br/>
-                <br/>
-                <b>Chinese</b><br/>
-                <b>Title:</b> {{ w.title_zh or '' }}<br/>
-                <b>Speaker:</b> {{ w.speaker_zh or '' }}<br/>
-                <b>Bible:</b> <span id="bible_verse_zh">{{ w.bible_zh or '' }}</span><br/>
-                <b>Outline:</b> {{ w.outline_zh or '' }}
-            </p>
-        </div>
+        {% set sermon_langs = [('zh', '中'), ('zh-TW', '台'), ('en', 'EN')] %}
+        {% for lang_key, label in sermon_langs %}
+            {% set sermon = w.sermons[lang_key] if w.sermons and w.sermons[lang_key] else {} %}
+            {% if sermon.title or sermon.speaker or sermon.bible or sermon.outline %}
+                <div class="card-row">
+                    <p>
+                        <b>{{ label }}</b><br/>
+                        <b>Title:</b> {{ sermon.title or '' }}<br/>
+                        <b>Speaker:</b> {{ sermon.speaker or '' }}<br/>
+                        <b>Bible:</b> <span id="bible_verse_{{ lang_key }}">{{ sermon.bible or '' }}</span><br/>
+                        <b>Outline:</b> {{ sermon.outline or '' }}
+                    </p>
+                </div>
+            {% endif %}
+        {% endfor %}
 
         <div class="card-row">
             <p>
@@ -197,8 +196,8 @@ span.chunk:before {
     const sharp = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
     const flat = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
 
-    const worshipData = {{ songs|tojson }};
-    const worshipInfo = {{ w|tojson }};
+    const worshipData = {{ songs|tojson|safe }};
+    const worshipInfo = {{ w|tojson|safe }};
     const initialTab = '{{ tab|safe }}' || 'view';
     const song_id = worshipData.map(o=> o.id);
 

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -138,15 +138,16 @@ span.chunk:before {
         <div class="card-row">
             <p>
                 <b>English</b><br/>
-                <b>Title:</b> {{ w.title_en or w.sermon_title }}<br/>
-                <b>Speaker:</b> {{ w.speaker_en or w.speaker }}<br/>
-                <b>Bible:</b> {{ w.bible_en or w.bible }}<br/>
+                <b>Title:</b> {{ w.title_en or '' }}<br/>
+                <b>Speaker:</b> {{ w.speaker_en or '' }}<br/>
+                <b>Bible:</b> <span id="bible_verse_en">{{ w.bible_en or '' }}</span><br/>
+                <b>Outline:</b> {{ w.outline_en or '' }}<br/>
                 <br/>
                 <b>Chinese</b><br/>
-                <b>Title:</b> {{ w.title_zh or w.sermon_title }}<br/>
-                <b>Speaker:</b> {{ w.speaker_zh or w.speaker }}<br/>
-                <b>Bible:</b> {{ w.bible_zh or w.bible }}<br/>
-                <b>Outline:</b> {{ w.outline }}
+                <b>Title:</b> {{ w.title_zh or '' }}<br/>
+                <b>Speaker:</b> {{ w.speaker_zh or '' }}<br/>
+                <b>Bible:</b> <span id="bible_verse_zh">{{ w.bible_zh or '' }}</span><br/>
+                <b>Outline:</b> {{ w.outline_zh or '' }}
             </p>
         </div>
 
@@ -196,8 +197,8 @@ span.chunk:before {
     const sharp = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
     const flat = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
 
-    const worshipData = {{ songs|safe }};
-    const worshipInfo = {{ w|safe }};
+    const worshipData = {{ songs|tojson }};
+    const worshipInfo = {{ w|tojson }};
     const initialTab = '{{ tab|safe }}' || 'view';
     const song_id = worshipData.map(o=> o.id);
 
@@ -347,12 +348,29 @@ span.chunk:before {
             document.title = `${worshipInfo.date} Worship Notes - Worship Manager`;
 
             // Bible Link generation logic
-            const bibleContainer = document.getElementById('bible_verse');
-            const bibleVerses = worshipInfo.bible.replace(/(、|;)/g, '，').split('，');
-        
-            bibleContainer.innerHTML = bibleVerses.map(v =>
-                ` <a href="javascript:void(0)" onclick="get_bible(show_verse, '${v.trim()}')">${v.trim()}</a>`
-            ).join('');
+            ['bible_verse_en', 'bible_verse_zh'].forEach((id) => {
+                const bibleContainer = document.getElementById(id);
+                if (!bibleContainer) {
+                    return;
+                }
+                const bibleText = (bibleContainer.textContent || '').trim();
+                if (!bibleText) {
+                    return;
+                }
+                const bibleVerses = bibleText.replace(/(、|;)/g, '，').split('，').map(v => v.trim()).filter(Boolean);
+                bibleContainer.innerHTML = '';
+
+                bibleVerses.forEach((verse, index) => {
+                    if (index > 0) {
+                        bibleContainer.appendChild(document.createTextNode(' '));
+                    }
+                    const link = document.createElement('a');
+                    link.href = 'javascript:void(0)';
+                    link.textContent = verse;
+                    link.onclick = () => get_bible(show_verse, verse);
+                    bibleContainer.appendChild(link);
+                });
+            });
         }
         // Load initial view
         loadTab(initialTab);

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -12,7 +12,7 @@
     background: #fdfdfd;
     border: 1px solid #e0e0e0;
     border-radius: 8px;
-    padding: 0px 15px;
+    padding: 15px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.04);
     margin: 15px auto;
     box-sizing: border-box;
@@ -127,13 +127,37 @@ span.chunk:before {
     width: 100%;
     height: 100%;
 }
+
+/* Sermon Box */
+#summary_container h3 {
+    margin-top: 0;
+}
+.sermon-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 8px;
+    margin-bottom: 12px;
+}
+.sermon-title { margin: 0; font-size: 1.3em; color: #2c3e50; }
+.sermon-speaker { font-weight: 600; color: #7f8c8d; background: #eaeded; padding: 4px 8px; border-radius: 4px; font-size: 0.9em;}
+.sermon-bible { font-size: 1.05em; margin-bottom: 12px; }
+.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; margin-bottom: 12px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
+
+/* Bible Link */
+.bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }
+.bible-link:hover { background: #009698; color: #fff; }
+
+
+
 </style>
 {% endblock %}
 
 {% block content %}
 
     <div id="summary_container" class="summary_container">
-        <h3>{{ w.date }} 敬拜筆記 (Worship Notes)</h3>
+        <!-- <h3>{{ w.date }} 敬拜筆記 (Worship Notes)</h3>
         {% set sermon_langs = [('zh', '中'), ('zh-TW', '台'), ('en', 'EN')] %}
         {% for lang_key, label in sermon_langs %}
             {% set sermon = w.sermons[lang_key] if w.sermons and w.sermons[lang_key] else {} %}
@@ -163,7 +187,7 @@ span.chunk:before {
                 <b>Worship Leader's Notes:</b><br/>
                 {{ w.notes }}
             </p>
-        </div>
+        </div> -->
 
 
     </div>
@@ -200,6 +224,77 @@ span.chunk:before {
     const worshipInfo = {{ w|tojson|safe }};
     const initialTab = '{{ tab|safe }}' || 'view';
     const song_id = worshipData.map(o=> o.id);
+
+    // Sermon Card Functions:
+    function get_sermon() {
+        function buildBibleLinks(bibleText) {
+            var bible = (bibleText || '').replace(/(、|;)/g, '，').split('，');
+            var b = '';
+            for (var i=0; i<bible.length; i++) {
+                var verse = bible[i].trim();
+                if (verse !== "") {
+                    var escapedVerse = verse.replace(/'/g, "\\'").replace(/"/g, '\\"');
+                    b += ' <a class="bible-link" href="javascript:void(0)" onclick="get_bible(show_verse, \'' + escapedVerse + '\'); return false;">' + verse + '</a>';
+                }
+            }
+            return b;
+        }
+
+        var sermonVariants = worshipInfo.sermons || {};
+        var sermonLangs = [
+            { key: 'zh', label: '中文', shortLabel: '中' },
+            { key: 'zh-TW', label: '台語', shortLabel: '台' },
+            { key: 'en', label: 'English', shortLabel: 'EN' }
+        ];
+
+        var titleHtml = "<h3>{{ w.date }} 敬拜筆記 (Worship Notes)</h3>";
+
+        var cardHtml = sermonLangs.filter(function(item) {
+            var sermon = sermonVariants[item.key] || {};
+            return sermon.title || sermon.speaker || sermon.bible || sermon.outline;
+        }).map(function(item) {
+            var sermon = sermonVariants[item.key] || {};
+            var bibleText = buildBibleLinks(sermon.bible || '');
+            return `
+                <div class="sermon-header">
+                    <h4 class="sermon-title"><strong>${item.label}:</strong> ${sermon.title || ''}</h4>
+                    <span class="sermon-speaker">By: ${sermon.speaker || ''}</span>
+                </div>
+                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleText}</div>
+                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${sermon.outline || ''}</div>
+            `;
+        }).join('');
+
+        var teamHtml = '';
+        if (worshipInfo.content && worshipInfo.content.length > 0) {
+            var teamRows = worshipInfo.content.map(function(team) {
+                return `<strong>${team.role}:</strong> ${team.user_name}`;
+            }).join('<br/>');
+
+            teamHtml = `
+                <div class="card-row" style="border-top: 1px solid #eee; padding-top: 12px;">
+                    <p>${teamRows}</p>
+                </div>
+            `;
+        }
+
+        var notesHtml = '';
+        if (worshipInfo.notes) {
+            notesHtml = `
+                <div class="card-row" style="border-top: 1px solid #eee; padding-top: 12px;">
+                    <p>
+                        <strong>Worship Leader's Notes:</strong><br/>
+                        ${worshipInfo.notes.replace(/\n/g, '<br/>')}
+                    </p>
+                </div>
+            `;
+        }
+
+        $('#summary_container').html(titleHtml + cardHtml + teamHtml + notesHtml);
+    }
+
+
+
 
     // --- FUNCTIONS ---
     /**
@@ -345,32 +440,10 @@ span.chunk:before {
     window.onload = () => {
         if (worshipInfo && worshipInfo.date) {
             document.title = `${worshipInfo.date} Worship Notes - Worship Manager`;
-
-            // Bible Link generation logic
-            ['bible_verse_en', 'bible_verse_zh'].forEach((id) => {
-                const bibleContainer = document.getElementById(id);
-                if (!bibleContainer) {
-                    return;
-                }
-                const bibleText = (bibleContainer.textContent || '').trim();
-                if (!bibleText) {
-                    return;
-                }
-                const bibleVerses = bibleText.replace(/(、|;)/g, '，').split('，').map(v => v.trim()).filter(Boolean);
-                bibleContainer.innerHTML = '';
-
-                bibleVerses.forEach((verse, index) => {
-                    if (index > 0) {
-                        bibleContainer.appendChild(document.createTextNode(' '));
-                    }
-                    const link = document.createElement('a');
-                    link.href = 'javascript:void(0)';
-                    link.textContent = verse;
-                    link.onclick = () => get_bible(show_verse, verse);
-                    bibleContainer.appendChild(link);
-                });
-            });
         }
+
+        get_sermon();
+
         // Load initial view
         loadTab(initialTab);
     };

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -137,9 +137,15 @@ span.chunk:before {
 
         <div class="card-row">
             <p>
-                <b>Title:</b> {{ w.sermon_title }}<br/>
-                <b>Speaker:</b> {{ w.speaker }}<br/>
-                <b>Bible:</b> <span id="bible_verse"></span><br/>
+                <b>English</b><br/>
+                <b>Title:</b> {{ w.title_en or w.sermon_title }}<br/>
+                <b>Speaker:</b> {{ w.speaker_en or w.speaker }}<br/>
+                <b>Bible:</b> {{ w.bible_en or w.bible }}<br/>
+                <br/>
+                <b>Chinese</b><br/>
+                <b>Title:</b> {{ w.title_zh or w.sermon_title }}<br/>
+                <b>Speaker:</b> {{ w.speaker_zh or w.speaker }}<br/>
+                <b>Bible:</b> {{ w.bible_zh or w.bible }}<br/>
                 <b>Outline:</b> {{ w.outline }}
             </p>
         </div>

--- a/web/templates/worship/notes.html
+++ b/web/templates/worship/notes.html
@@ -149,7 +149,111 @@ span.chunk:before {
 .bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }
 .bible-link:hover { background: #009698; color: #fff; }
 
+/* =========================================
+   Media Icons Container & Dropdown Styling
+   ========================================= */
+.media-icons-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: 12px;
+    vertical-align: middle;
+}
 
+/* Force both single <a> links and .media-dropdown wrappers to share identical alignment */
+.media-icons-wrapper > a,
+.media-icons-wrapper > .media-dropdown {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    text-decoration: none;
+    line-height: 1;
+}
+
+/* Ensure all font icons render at an identical size and vertical height */
+.media-icons-wrapper i {
+    font-size: 22px !important;
+    line-height: 1 !important;
+}
+
+/* Container for the icon + badge */
+.media-dropbtn {
+    cursor: pointer;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #333;
+    padding-right: 6px; /* Reserves layout space so the badge doesn't hit the next icon */
+}
+
+/* Badge pinned neatly to the top-right corner of the icon */
+.media-dropbtn .badge {
+    background-color: #dc3545;
+    color: white;
+    border-radius: 10px;
+    padding: 1px 5px;
+    font-size: 10px;
+    position: absolute;
+    top: -4px;
+    right: -2px;
+    font-weight: bold;
+    line-height: 1;
+    box-shadow: 0 0 0 2px #ffffff;
+    z-index: 2;
+}
+
+.media-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #fff;
+    min-width: 110px;
+    box-shadow: 0px 4px 12px rgba(0,0,0,0.15);
+    z-index: 100;
+    border-radius: 5px;
+    border: 1px solid #eee;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 5px 0;
+}
+
+.media-dropdown-content a {
+    color: #333;
+    padding: 8px 15px;
+    text-decoration: none;
+    display: block;
+    font-size: 13px;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.media-dropdown-content a:hover {
+    background-color: #f5f5f5;
+    color: #009698;
+}
+
+.media-dropdown:hover .media-dropdown-content {
+    display: block;
+}
+
+/* =========================================
+   Video Grid
+   ========================================= */
+.video-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center; /* Centers the videos if there's an odd number */
+    margin-bottom: 30px;
+}
+
+/* Update your existing .video-container to work within the grid */
+.video-container {
+    flex: 1 1 400px; /* Try to be 400px wide, but shrink on mobile screens */
+    max-width: 640px; 
+    aspect-ratio: 16 / 9;
+}
 
 </style>
 {% endblock %}
@@ -157,39 +261,7 @@ span.chunk:before {
 {% block content %}
 
     <div id="summary_container" class="summary_container">
-        <!-- <h3>{{ w.date }} 敬拜筆記 (Worship Notes)</h3>
-        {% set sermon_langs = [('zh', '中'), ('zh-TW', '台'), ('en', 'EN')] %}
-        {% for lang_key, label in sermon_langs %}
-            {% set sermon = w.sermons[lang_key] if w.sermons and w.sermons[lang_key] else {} %}
-            {% if sermon.title or sermon.speaker or sermon.bible or sermon.outline %}
-                <div class="card-row">
-                    <p>
-                        <b>{{ label }}</b><br/>
-                        <b>Title:</b> {{ sermon.title or '' }}<br/>
-                        <b>Speaker:</b> {{ sermon.speaker or '' }}<br/>
-                        <b>Bible:</b> <span id="bible_verse_{{ lang_key }}">{{ sermon.bible or '' }}</span><br/>
-                        <b>Outline:</b> {{ sermon.outline or '' }}
-                    </p>
-                </div>
-            {% endif %}
-        {% endfor %}
-
-        <div class="card-row">
-            <p>
-                {% for team in w.content %}
-                    {{ team.role }}: {{ team.user_name }}<br/>
-                {% endfor %}
-            </p>
-        </div>
-
-        <div class="card-row">
-            <p>
-                <b>Worship Leader's Notes:</b><br/>
-                {{ w.notes }}
-            </p>
-        </div> -->
-
-
+        <!-- Dynamically populated by get_sermon() -->
     </div>
     
     <!-- Container of worship songs -->
@@ -225,7 +297,11 @@ span.chunk:before {
     const initialTab = '{{ tab|safe }}' || 'view';
     const song_id = worshipData.map(o=> o.id);
 
-    // Sermon Card Functions:
+    // --- FUNCTIONS ---
+
+    /**
+    * Builds and injects the Sermon Card HTML
+    */
     function get_sermon() {
         function buildBibleLinks(bibleText) {
             var bible = (bibleText || '').replace(/(、|;)/g, '，').split('，');
@@ -293,10 +369,6 @@ span.chunk:before {
         $('#summary_container').html(titleHtml + cardHtml + teamHtml + notesHtml);
     }
 
-
-
-
-    // --- FUNCTIONS ---
     /**
     * Transposes a single chord string (e.g., "G/B") by a specific number of steps (diff).
     */
@@ -383,6 +455,51 @@ span.chunk:before {
     }
 
     /**
+    * Generate Dropdowns for Media Links
+    */
+    function getMediaLinksHtml(item) {
+        let html = '';
+
+        // Sheet Music Links (Score)
+        if (item.score && item.score.length > 0) {
+            if (item.score.length === 1) {
+                html += `<a href="${item.score[0]}" target="_blank"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>`;
+            } else {
+                html += `<div class="media-dropdown">
+                    <span class="media-dropbtn"><i class="fa" style="font-size:24px" title="Sheet Music">&#xf0f6;</i><span class="badge">${item.score.length}</span></span>
+                    <div class="media-dropdown-content">`;
+                item.score.forEach((link, idx) => {
+                    html += `<a href="${link}" target="_blank">Sheet Music ${idx + 1}</a>`;
+                });
+                html += `</div></div>`;
+            }
+        }
+
+        // ABC Interactive Sheets
+        if (item.abc && item.abc.length > 0) {
+            html += `<a href="/worship/sheets/${item.id}" target="_blank"><i style="font-size:24px" class="fa" title="Interactive Sheet Music">&#xf1c7;</i></a>`;
+        }
+
+        // Video Links
+        if (item.video && item.video.length > 0) {
+            if (item.video.length === 1) {
+                html += `<a href="${item.video[0]}" target="_blank"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>`;
+            } else {
+                html += `<div class="media-dropdown">
+                    <span class="media-dropbtn"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Videos"></i><span class="badge">${item.video.length}</span></span>
+                    <div class="media-dropdown-content">`;
+                item.video.forEach((link, idx) => {
+                    html += `<a href="${link}" target="_blank">Video ${idx + 1}</a>`;
+                });
+                html += `</div></div>`;
+            }
+        }
+        
+        // Return wrapped inside our flexbox container if there are links
+        return html ? `<span class="media-icons-wrapper">${html}</span>` : '';
+    }
+
+    /**
     * Loads the tab based on the button that was clicked (view, chord, bi, video) and updates the content accordingly.
     */
     function loadTab(mode) {
@@ -400,10 +517,17 @@ span.chunk:before {
             }
 
             if (mode === 'video') {
-                let videoUrl = item.video.replace('youtu.be/', 'www.youtube.com/embed/').replace('watch?v=', 'embed/');
-                finalHtml += `<div class="video-container"><iframe src="${videoUrl}"></iframe></div><br/>`;
-            }else {
-                //Build the Header
+                if (item.video && item.video.length > 0) {
+                    finalHtml += `<div style="text-align: center; margin-bottom: 15px; font-weight: bold; font-size: 1.2em;">${item.title}</div>`;
+                    
+                    finalHtml += `<div class="video-grid">`;
+                    item.video.forEach(v => {
+                        let videoUrl = v.replace('youtu.be/', 'www.youtube.com/embed/').replace('watch?v=', 'embed/');
+                        finalHtml += `<div class="video-container"><iframe src="${videoUrl}" frameborder="0" allowfullscreen></iframe></div>`;
+                    });
+                    finalHtml += `</div>`;
+                }
+            } else {
                 let currentKey = transposeChord(item.song_key, parseInt(item.transpose));
                 let header = `
                     <div class="songs">
@@ -411,15 +535,13 @@ span.chunk:before {
                             ${item.title} (${currentKey})
                             ${getLangTag(item.lang)} ${getLangTag(item.lang_2)} 
                             [${item.alt_sequence}]
-                            ${item.score ? `&nbsp;&nbsp;<a href="${item.score}" target="_blank"><i style="font-size:24px" class="fa" title="Sheet Music">&#xf0f6;</i></a>` : ''}
-                            ${item.abc ? `&nbsp;&nbsp;<a href="/worship/sheets/${item.id}" target="_blank"><i style="font-size:24px" class="fa" title="Interactive Sheet Music">&#xf1c7;</i></a>` : ''}
-                            ${item.video ? `&nbsp;&nbsp;<a href="${item.video}" target="_blank"><i class="fa fa-play-circle" style="font-size:24px" title="Youtube Video"></i></a>` : ''}
+                            ${getMediaLinksHtml(item)}
                         </div>
                         <div class="song_container">
                             <div class="song_block">${renderSongContent(item, mode)}</div>
                             <div class="notes">${item.notes.replace(/\n/g, '<br/>')}</div>
                         </div>
-                    </div>`;
+                    </div><br/>`;
                 finalHtml += header;
             }
         }

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -234,6 +234,90 @@ li {
 }
 
 /* =========================================
+   Media Icons & Dropdowns
+   ========================================= */
+.media-icons-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 15px; 
+    /* margin-left: 10px; */
+    vertical-align: middle;
+}
+
+.media-icons-wrapper > a,
+.media-icons-wrapper > .media-dropdown {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    text-decoration: none;
+    line-height: 1;
+}
+
+.media-icons-wrapper i {
+    font-size: 22px !important;
+    line-height: 1 !important;
+}
+
+.media-dropbtn {
+    cursor: pointer;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #333;
+    padding-right: 6px; 
+}
+
+.media-dropbtn .badge {
+    background-color: #dc3545;
+    color: white;
+    border-radius: 10px;
+    padding: 1px 5px;
+    font-size: 10px;
+    position: absolute;
+    top: -4px;        
+    right: -2px;      
+    font-weight: bold;
+    line-height: 1;
+    box-shadow: 0 0 0 2px #ffffff;
+    z-index: 2;
+}
+
+.media-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #fff;
+    min-width: 110px;
+    box-shadow: 0px 4px 12px rgba(0,0,0,0.15);
+    z-index: 100;
+    border-radius: 5px;
+    border: 1px solid #eee;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 5px 0;
+}
+
+.media-dropdown-content a {
+    color: #333;
+    padding: 8px 15px;
+    text-decoration: none;
+    display: block;
+    font-size: 13px;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.media-dropdown-content a:hover {
+    background-color: #f5f5f5;
+    color: #009698;
+}
+
+.media-dropdown:hover .media-dropdown-content {
+    display: block;
+}
+
+/* =========================================
    Badge Tag Things
    ========================================= */
 /* Key Tag */
@@ -426,12 +510,13 @@ li {
                                 <button type="button" class="icon-button insert_btn" title="Add Song"><i class="fa-solid fa-plus"></i></button>
                                 <span class="song_title"><b>${s1.title}</b></span>
                                 <span class="keynote">${s1.key}</span>
-                                ${lang_tag(s1.lang)} ${lang_tag(s1.lang_2)}
+                                ${lang_tag(s1.lang)} ${lang_tag(s1.lang_2)} ${get_links(s1.video, s1.score, s1.abc, s1.id)}
                             </div>`;
                     }
                 }
             }
             $('#left_content').append(my_song_list);
+            console.log(data)
         });
 
         get_songs().done(function(data) {

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -374,10 +374,10 @@ li {
         Global Variables
     ================================== */
     // Store worship set into object
-    let songs = {{ songs|safe }};
+    let songs = {{ songs|tojson|safe }};
     let songs_temp = JSON.parse(JSON.stringify(songs));
     let lyrics_raw = '';
-    let worship_data = {{ w|tojson }};
+    let worship_data = {{ w|tojson|safe }};
     let worship_id = {{ id|safe }};
     let worship = $('#worship');
 
@@ -475,31 +475,37 @@ li {
             var bible = (bibleText || '').replace(/(、|;)/g, '，').split('，');
             var b = '';
             for (var i=0; i<bible.length; i++) {
-                if (bible[i].trim() !== "") {
-                    b += ' <a class="bible-link" href="javascript:get_bible(show_verse, \'" + bible[i] + "\')">' + bible[i] + '</a>';
+                var verse = bible[i].trim();
+                if (verse !== "") {
+                    var escapedVerse = verse.replace(/'/g, "\\'").replace(/"/g, '\\"');
+                    b += ' <a class="bible-link" href="javascript:void(0)" onclick="get_bible(show_verse, \'' + escapedVerse + '\'); return false;">' + verse + '</a>';
                 }
             }
             return b;
         }
 
-        var bibleZh = buildBibleLinks(worship_data.bible_zh || worship_data.bible || '');
-        var bibleEn = buildBibleLinks(worship_data.bible_en || worship_data.bible || '');
+        var sermonVariants = worship_data.sermons || {};
+        var sermonLangs = [
+            { key: 'zh', label: '中文', shortLabel: '中' },
+            { key: 'zh-TW', label: '台語', shortLabel: '台' },
+            { key: 'en', label: 'English', shortLabel: 'EN' }
+        ];
 
-        var cardHtml = `
+        var cardHtml = sermonLangs.filter(function(item) {
+            var sermon = sermonVariants[item.key] || {};
+            return sermon.title || sermon.speaker || sermon.bible || sermon.outline;
+        }).map(function(item) {
+            var sermon = sermonVariants[item.key] || {};
+            var bibleText = buildBibleLinks(sermon.bible || '');
+            return `
                 <div class="sermon-header">
-                    <h4 class="sermon-title"><strong>中文:</strong> ${worship_data.title_zh}</h4>
-                    <span class="sermon-speaker">By: ${worship_data.speaker_zh}</span>
+                    <h4 class="sermon-title"><strong>${item.label}:</strong> ${sermon.title || ''}</h4>
+                    <span class="sermon-speaker">By: ${sermon.speaker || ''}</span>
                 </div>
-                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleZh}</div>
-                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${worship_data.outline_zh || worship_data.outline || ''}</div>
-
-                <div class="sermon-header">
-                    <h4 class="sermon-title"><strong>English:</strong> ${worship_data.title_en}</h4>
-                    <span class="sermon-speaker">By: ${worship_data.speaker_en}</span>
-                </div>
-                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleEn}</div>
-                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${worship_data.outline_en || worship_data.outline || ''}</div>
-        `;
+                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleText}</div>
+                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${sermon.outline || ''}</div>
+            `;
+        }).join('');
         $('#sermon-data_card').html(cardHtml);
     }
 

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -377,7 +377,7 @@ li {
     let songs = {{ songs|safe }};
     let songs_temp = JSON.parse(JSON.stringify(songs));
     let lyrics_raw = '';
-    let worship_data = {{ w|safe }};
+    let worship_data = {{ w|tojson }};
     let worship_id = {{ id|safe }};
     let worship = $('#worship');
 

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -516,7 +516,6 @@ li {
                 }
             }
             $('#left_content').append(my_song_list);
-            console.log(data)
         });
 
         get_songs().done(function(data) {

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -3,83 +3,23 @@
 {% block page_title %}{{ w.date }} Worship Songs{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="/static/css/worship-shared.css">
 <style>
-
 /* =========================================
-    General Stuff
+   Core Layout & Containers
    ========================================= */
-#songs { text-align:left; list-style-type: none; margin: 0; padding: 0;}
-.lyrics {
-    text-align:center;
-    list-style-type: none;
-    margin: 0; padding: 0;
-    width: 100%;
-}
-
-/* This might not be working */
-#songs, .lyrics li { margin: 0 3px 3px 3px; padding: 0.2em; font-size: 1em}
-
-/* =========================================
-   Shared Card Styling
-   ========================================= */
-.app-card {
-    background: #fdfdfd;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 15px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.04);
-    margin: 15px auto;
-    box-sizing: border-box;
-}
-
-/* Worship and Song List containers */
-#worship {
+#worship, #song_list {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-self: center;
 }
 
+/* Override */
 #song_list {
-    display: flex;
-    justify-content: center;
-    align-self: center;
+    flex-direction: row;
 }
 
-.arrow {
-    padding: 2px;
-    margin: 2px;
-}
-
-.arrow:hover {
-    cursor: pointer;
-    border: 1px solid #d0d0d0;
-}
-
-/* =========================================
-   Sermon Box
-   ========================================= */
-.sermon-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 2px solid #eee;
-    padding-bottom: 8px;
-    margin-bottom: 12px;
-}
-.sermon-title { margin: 0; font-size: 1.3em; color: #2c3e50; }
-.sermon-speaker { font-weight: 600; color: #7f8c8d; background: #eaeded; padding: 4px 8px; border-radius: 4px; font-size: 0.9em;}
-.sermon-bible { font-size: 1.05em; margin-bottom: 12px; }
-.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; margin-bottom: 12px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
-
-/* Bible Link */
-.bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }
-.bible-link:hover { background: #009698; color: #fff; }
-
-/* =========================================
-   Worship Song Card Flexbox (3 Rows)
-   ========================================= */
 .empty-state {
     text-align: center;
     padding: 30px 20px;
@@ -91,50 +31,77 @@
     margin: 10px;
 }
 
-/* Stacks the three rows vertically */
+/* Navigation Arrows */
+.arrow {
+    padding: 2px;
+    margin: 2px;
+}
+.arrow:hover {
+    cursor: pointer;
+    border: 1px solid #d0d0d0;
+}
+
+/* =========================================
+   Song Editor Cards & Lists
+   ========================================= */
+
+#songs, .lyrics {
+    text-align:left;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Override */
+.lyrics {
+    text-align:center;
+}
+
+#songs li, .lyrics li, #song_list li {
+    border-radius: 5px;
+    margin: 5px;
+    padding: 5px;
+    font-size: 1em;
+}
+
 .song-content-wrapper {
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: 10px;
-    width: 100%;
     padding: 5px;
 }
 
-/* Flexbox for the top row */
 .song-header-row {
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
 }
 
 .song-title {
-    margin: 3px 3px 3px 3px;
+    margin: 3px;
     border: 1px solid transparent;
 }
 
-/* Flexbox for the middle row (keys and icons) */
 .song-details-row {
     display: flex;
-    flex-direction: row;
     align-items: center;
     gap: 15px;
     flex-wrap: wrap;
 }
 
-/*  The p of song-notes for some reason has a bottom margin being applied.
-    Adding this to just get rid of it. */
-.song-notes-row p { margin: 0; }
+.song-notes-row p {
+    margin: 0;
+}
 
 .song-notes-row textarea {
-    width: 100%; /* Makes the text area span the full width of the card */
-    max-width: 100%;
+    width: 100%;
     box-sizing: border-box;
 }
 
 /* =========================================
-    Lyrics Flexbox and Sequence Highlighting
+   Lyrics & Sequences
    ========================================= */
 .lyric-item {
     display: flex;
@@ -142,69 +109,25 @@
     align-items: flex-start;
     padding: 10px;
     margin: 10px 0px;
-    /* background-color: #fcfcfc; */
     border: 1px solid #eee;
     border-radius: 4px;
 }
-.lyric-content {
-    flex-grow: 0.5;
-    text-align: center;
-    padding: 5px;
-    margin: 5px;
-    border-radius: 4px;
-}
 
+.lyric-content { flex-grow: 0.5; text-align: center; padding: 5px; margin: 5px; border-radius: 4px; }
 .lyrics_buttons { display: flex; gap: 8px; flex-shrink: 0; }
 
+.sequence-container { display: flex; flex-direction: column; align-items: flex-start; }
+.song_sequence_toggle { display: flex; align-items: center; cursor: pointer; gap: 8px; }
+
+/* Sequence Colored Tags */
 .p { background-color: #f78787; color: #fff}
-.v, [class~="1"], [class~="2"], [class~="3"], [class~="4"], [class~="5"], [class~="6"], [class~="7"], [class~="8"] { 
-    background-color: #D6B588; 
-    color: #fff; 
-}
+.v, [class~="1"], [class~="2"], [class~="3"], [class~="4"], [class~="5"], [class~="6"], [class~="7"], [class~="8"] { background-color: #D6B588; color: #fff; }
 .chorus, .Chorus, .c { background-color: #556b2f; color: #fff}
 .bridge, .b, .b2, .b3, .b4 { background-color: #003153; color: #fff}
-
-.sequence-container {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-}
-
-.song_sequence_toggle {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 8px;
-}
-
-#song_list > div {
-  width: 50%;
-  margin: 5px 5px 5px 5px;
-  text-align: left;
-  font-size: 14px;
-}
-
-li {
-  border-radius: 5px;
-  margin: 5px;
-  padding: 5px;
-}
-
-.highlighted {
-    font-weight: 400;
-    color: red;
-}
 
 /* =========================================
    Buttons
    ========================================= */
-.action_btn_container {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 10px;
-}
-
 .save_btn { background-color: #28a745; color: white; border-color: #28a745; }
 .save_btn:hover { background-color: #218838; }
 
@@ -219,12 +142,8 @@ li {
     transition: background-color 0.2s ease;
     margin-left: auto;
 }
+.remove_btn:hover { background-color: #ee8686; }
 
-.remove_btn:hover {
-    background-color: #ee8686;
-}
-
-/* This resets global button styles for specific icon buttons */
 .icon-button {
     background: none !important;
     padding: 0 !important;
@@ -234,129 +153,17 @@ li {
 }
 
 /* =========================================
-   Media Icons & Dropdowns
+   Sidebar / Search Results
    ========================================= */
-.media-icons-wrapper {
-    display: inline-flex;
-    align-items: center;
-    gap: 15px; 
-    /* margin-left: 10px; */
-    vertical-align: middle;
-}
+#song_list > div { width: 50%; margin: 5px; text-align: left; font-size: 14px; }
 
-.media-icons-wrapper > a,
-.media-icons-wrapper > .media-dropdown {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    text-decoration: none;
-    line-height: 1;
-}
-
-.media-icons-wrapper i {
-    font-size: 22px !important;
-    line-height: 1 !important;
-}
-
-.media-dropbtn {
-    cursor: pointer;
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    color: #333;
-    padding-right: 6px; 
-}
-
-.media-dropbtn .badge {
-    background-color: #dc3545;
-    color: white;
-    border-radius: 10px;
-    padding: 1px 5px;
-    font-size: 10px;
-    position: absolute;
-    top: -4px;        
-    right: -2px;      
-    font-weight: bold;
-    line-height: 1;
-    box-shadow: 0 0 0 2px #ffffff;
-    z-index: 2;
-}
-
-.media-dropdown-content {
-    display: none;
-    position: absolute;
-    background-color: #fff;
-    min-width: 110px;
-    box-shadow: 0px 4px 12px rgba(0,0,0,0.15);
-    z-index: 100;
-    border-radius: 5px;
-    border: 1px solid #eee;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 5px 0;
-}
-
-.media-dropdown-content a {
-    color: #333;
-    padding: 8px 15px;
-    text-decoration: none;
-    display: block;
-    font-size: 13px;
-    text-align: left;
-    white-space: nowrap;
-}
-
-.media-dropdown-content a:hover {
-    background-color: #f5f5f5;
-    color: #009698;
-}
-
-.media-dropdown:hover .media-dropdown-content {
-    display: block;
-}
-
-/* =========================================
-   Badge Tag Things
-   ========================================= */
-/* Key Tag */
-   .keynote {
-  border: 4px solid #000;
-  background-color: #000;
-  color: #fff;
-  border-radius: 5px;
-}
-
-/* Language tags */
-.lang_en    { --lang-color: #009698; }
-.lang_zh    { --lang-color: #8b0000; }
-.lang_zhTW  { --lang-color: #556b2f; }
-.lang_zhpingyin { --lang-color: #856088; }
-
-.lang_en, .lang_zh, .lang_zhTW, .lang_zhpingyin {
-    border-radius: 50px 20px;
-    color: #fff;
-    border: 4px solid var(--lang-color);
-    background-color: var(--lang-color);
-}
-
-/* =========================================
-   Sidebar / Search List Items
-   ========================================= */
-.sidebar-section-title {
-    font-size: 16px;
-    font-weight: 600;
-    padding: 5px;
-    margin-top: 15px;
-    border-bottom: 2px solid #eee;
-}
+.sidebar-section-title { font-size: 16px; font-weight: 600; padding: 5px; margin-top: 15px; border-bottom: 2px solid #eee; }
 
 .sidebar-song-item {
     display: flex;
     align-items: center;
-    flex-wrap: wrap; /* Allows items to wrap on tiny screens */
-    gap: 8px; /* Spacing between the button, title, and tags */
+    flex-wrap: wrap; 
+    gap: 8px; 
     padding: 6px 8px;
     margin: 4px 0;
     border-radius: 6px;
@@ -364,26 +171,27 @@ li {
     border: 1px solid #f0f0f0;
     transition: background-color 0.2s ease;
 }
+.sidebar-song-item:hover { background-color: #f9f9f9; }
 
-.sidebar-song-item:hover {
-    background-color: #f9f9f9;
+.insert_btn { color: #28a745 !important; font-size: 1.1em; cursor: pointer; transition: transform 0.1s ease; }
+.insert_btn:hover { transform: scale(1.2) !important; }
+
+.keynote {
+  border: 4px solid #000;
+  background-color: #000;
+  color: #fff;
+  border-radius: 5px;
 }
 
-/* Specific styling for the new visible Insert (+) Button */
-.insert_btn {
-    color: #28a745 !important;
-    font-size: 1.1em;
-    cursor: pointer;
-    transition: transform 0.1s ease;
-}
-
-.insert_btn:hover {
-    transform: scale(1.2) !important;
-}
+.highlighted { font-weight: 400; color: red; }
 
 /* =========================================
-   Modal Button Overrides
-========================================= */
+   Modal Override
+   ========================================= */
+.ui-dialog { width: 95% !important; box-sizing: border-box; }
+@media (min-width: 768px) {
+    .ui-dialog { width: 75% !important; }
+}
 
 .ui-dialog-buttonset .btn {
     padding: 10px 25px !important;
@@ -395,24 +203,11 @@ li {
 .ui-dialog-buttonset .btn:hover, 
 .ui-dialog-buttonset .btn.ui-state-hover,
 .ui-dialog-buttonset .btn:focus {
-    transform: none !important; /* Kills the zoom/shift */
+    transform: none !important;
     scale: 1 !important;
     border: none !important;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2) !important; /* Safe hover effect */
-    font-weight: bold !important; /* Stops jQuery from un-bolding the text */
-}
-
-/* Default rules for mobile devices */
-.ui-dialog {
-    width: 95% !important; /* Almost full screen on mobile */
-    box-sizing: border-box;
-}
-
-/* Rules for desktop screens (screens wider than 768px) */
-@media (min-width: 768px) {
-    .ui-dialog {
-        width: 75% !important; /* 75% width on desktop */
-    }
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2) !important;
+    font-weight: bold !important;
 }
 </style>
 {% endblock %}

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -471,21 +471,34 @@ li {
 
     // Sermon Card Functions:
     function get_sermon() {
-        var bible = worship_data.bible.replace(/(、|;)/g, '，').split('，');; // Replace possible symbols to Chinese comma, then split by commas
-        var b = '';
-        for (var i=0; i<bible.length; i++) {
-            if(bible[i].trim() !== "") {
-                b += ' <a class="bible-link" href="javascript:get_bible(show_verse, \'' + bible[i] + '\')">' + bible[i] + '</a>';
+        function buildBibleLinks(bibleText) {
+            var bible = (bibleText || '').replace(/(、|;)/g, '，').split('，');
+            var b = '';
+            for (var i=0; i<bible.length; i++) {
+                if (bible[i].trim() !== "") {
+                    b += ' <a class="bible-link" href="javascript:get_bible(show_verse, \'" + bible[i] + "\')">' + bible[i] + '</a>';
+                }
             }
+            return b;
         }
+
+        var bibleZh = buildBibleLinks(worship_data.bible_zh || worship_data.bible || '');
+        var bibleEn = buildBibleLinks(worship_data.bible_en || worship_data.bible || '');
 
         var cardHtml = `
                 <div class="sermon-header">
-                    <h4 class="sermon-title"><strong>Title:</strong> ${worship_data.title}</h4>
-                    <span class="sermon-speaker">By: ${worship_data.speaker}</span>
+                    <h4 class="sermon-title"><strong>中文:</strong> ${worship_data.title_zh}</h4>
+                    <span class="sermon-speaker">By: ${worship_data.speaker_zh}</span>
                 </div>
-                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${b}</div>
-                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${worship_data.outline}</div>
+                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleZh}</div>
+                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${worship_data.outline_zh || worship_data.outline || ''}</div>
+
+                <div class="sermon-header">
+                    <h4 class="sermon-title"><strong>English:</strong> ${worship_data.title_en}</h4>
+                    <span class="sermon-speaker">By: ${worship_data.speaker_en}</span>
+                </div>
+                <div class="sermon-bible"><strong>Scripture Reference:</strong> ${bibleEn}</div>
+                <div class="sermon-outline"><strong>Sermon Outline:</strong><br/>${worship_data.outline_en || worship_data.outline || ''}</div>
         `;
         $('#sermon-data_card').html(cardHtml);
     }

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -71,7 +71,7 @@
 .sermon-title { margin: 0; font-size: 1.3em; color: #2c3e50; }
 .sermon-speaker { font-weight: 600; color: #7f8c8d; background: #eaeded; padding: 4px 8px; border-radius: 4px; font-size: 0.9em;}
 .sermon-bible { font-size: 1.05em; margin-bottom: 12px; }
-.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
+.sermon-outline { color: #34495e; line-height: 1.6; background: #f9f9f9; padding: 10px; margin-bottom: 12px; border-radius: 4px; border-left: 3px solid #bdc3c7; }
 
 /* Bible Link */
 .bible-link { color: #009698; text-decoration: none; font-weight: bold; margin-right: 6px; padding: 2px 6px; border: 1px solid #009698; border-radius: 4px; background: #f0fbfc; }

--- a/web/templates/worship/songs.html
+++ b/web/templates/worship/songs.html
@@ -409,7 +409,7 @@ li {
                             <button type="button" class="icon-button insert_btn" title="Add Song"><i class="fa-solid fa-plus"></i></button>
                             <span class="song_title"><b>${s.title}</b></span>
                             <span class="keynote">${s.key}</span>
-                            ${lang_tag(s.lang)} ${lang_tag(s.lang_2)} ${get_links(s.video, s.score, s.abc)}
+                            ${lang_tag(s.lang)} ${lang_tag(s.lang_2)} ${get_links(s.video, s.score, s.abc, s.id)}
                         </div>`;
                 }
             $('#left_content').append(my_pinned_songs);
@@ -442,7 +442,7 @@ li {
                         <button type="button" class="icon-button insert_btn" title="Add Song"><i class="fa-solid fa-plus"></i></button>
                         <span class="song_title"><b>${s.title}</b></span>
                         <span class="keynote">${s.key}</span>
-                        ${lang_tag(s.lang)} ${lang_tag(s.lang_2)} ${get_links(s.video, s.score, s.abc)}
+                        ${lang_tag(s.lang)} ${lang_tag(s.lang_2)} ${get_links(s.video, s.score, s.abc, s.id)}
                     </div>`;
             }
             $('#left_content').append(my_new_songs);
@@ -900,8 +900,8 @@ li {
                         <button type="button" class="icon-button insert_btn" title="Add Song"><i class="fa-solid fa-plus"></i></button>
                         <span class="song_title"><b>${highlight_keyword(keyword, data['right'][i]['title'])}</b></span> 
                         <span class="keynote">${data['right'][i]['key']}</span> 
-                        ${lang_tag(data['right'][i]['lang'])} ${lang_tag(data['right'][i]['lang_2'])} 
-                        ${get_links(data['right'][i]['video'], data['right'][i]['score'], data['right'][i]['abc'])}
+                        ${lang_tag(data['right'][i]['lang'])} ${lang_tag(data['right'][i]['lang_2'])}
+                        ${get_links(data['right'][i]['video'], data['right'][i]['score'], data['right'][i]['abc'], data['right'][i]['id'])}
                     </div>`;
             }
 
@@ -969,6 +969,7 @@ li {
             get_song(id).done(function(data) {
                 if(songs_temp.find(o => o.title === data.title)) {
                     alert('"' + data.title + '"is already in the set!');
+                    stopLoading();
                     return false;
                 }
                 data['date'] = worship_data.date;

--- a/web/templates/worship/worship.html
+++ b/web/templates/worship/worship.html
@@ -155,18 +155,21 @@
                 <div class="card-front">
                     <h3>{{ w.date }}</h3>
                     {% if w.worship %}
+                        {% set sermon_order = w.worship.display_order or ['zh', 'en'] %}
                         <div class="sermon-preview-container">
                             {% if w.worship.is_joint %}
                                 <div class="joint-badge">Joint</div>
                             {% endif %}
-                            <div class="sermon-preview-block">
-                                <b>中</b>: {{ w.worship.title_zh or '' }}<br/>
-                                <small>{{ w.worship.speaker_zh or '' }}</small>
-                            </div>
-                            <div class="sermon-preview-block">
-                                <b>EN</b>: {{ w.worship.title_en or '' }}<br/>
-                                <small>{{ w.worship.speaker_en or '' }}</small>
-                            </div>
+                            {% for lang_key in sermon_order %}
+                                {% set sermon_variant = w.worship.sermons[lang_key] if w.worship.sermons and w.worship.sermons[lang_key] else {} %}
+                                {% if sermon_variant.title or sermon_variant.speaker or sermon_variant.bible or sermon_variant.outline %}
+                                    {% set label = '中' if lang_key == 'zh' else '台' if lang_key == 'zh-TW' else 'EN' %}
+                                    <div class="sermon-preview-block">
+                                        <b>{{ label }}</b>: {{ sermon_variant.title or '' }}<br/>
+                                        <small>{{ sermon_variant.speaker or '' }}</small>
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
                             <div>Notes: {{ (w.worship.notes or '')|string|truncate(100) }}</div>
                         </div>
                     {% endif %}
@@ -210,7 +213,7 @@ let inst;
 let marked;
 let worship_id = -1;
 let activeCard = null;
-let sundays = {{ sundays|safe }};
+let sundays = {{ sundays|tojson|safe }};
 
     function pop_role(name) {
         for (i in taken_role) {
@@ -345,55 +348,121 @@ let sundays = {{ sundays|safe }};
             .replace(/'/g, '&#39;');
     }
 
+    function getSermonVariant(sermons, langKey) {
+        return (sermons && sermons[langKey]) || {};
+    }
+
+    function getPreferredSermonKey(sermons, displayOrder) {
+        var order = displayOrder && displayOrder.length ? displayOrder : ['zh', 'en'];
+        for (var i = 0; i < order.length; i++) {
+            var langKey = order[i];
+            var variant = getSermonVariant(sermons, langKey);
+            if (variant && (variant.title || variant.speaker || variant.bible || variant.outline)) {
+                return langKey;
+            }
+        }
+        return 'zh';
+    }
+
+    function getLanguageLabel(langKey) {
+        if (langKey === 'zh-TW') return '台';
+        if (langKey === 'en') return 'EN';
+        return '中';
+    }
+
+    function buildSermonPreviewHtml(sermonData) {
+        var html = '';
+        if (sermonData.is_joint) {
+            html += '<div class="joint-badge">Joint</div>';
+        }
+        var displayOrder = sermonData.display_order && sermonData.display_order.length ? sermonData.display_order : ['zh', 'en'];
+        displayOrder.forEach(function(langKey) {
+            var langVariant = getSermonVariant(sermonData.sermons, langKey);
+            if (langVariant.title || langVariant.speaker || langVariant.bible || langVariant.outline) {
+                html += '<div class="sermon-preview-block"><b>' + getLanguageLabel(langKey) + '</b>: ' + escapeHtml(langVariant.title || '') + '<br/><small>' + escapeHtml(langVariant.speaker || '') + '</small></div>';
+            }
+        });
+        html += '<div>Notes: ' + escapeHtml(sermonData.notes || '') + '</div>';
+        return html;
+    }
+
+    function buildSermonEditorHtml(sermonData, selectedLang, sermonLangs) {
+        var html = '';
+        html += '<div style="display:flex;flex-wrap:wrap;gap:12px;">';
+        sermonData.display_order.forEach(function(langKey) {
+            var langVariant = getSermonVariant(sermonData.sermons, langKey);
+            html += '<div style="flex:1 1 240px;min-width:240px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
+            html += '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">';
+            html += '<b>' + getLanguageLabel(langKey) + '</b>';
+            html += '<button type="button" class="sermon-remove-lang" data-lang-key="' + langKey + '" style="padding:4px 8px;">Remove</button>';
+            html += '</div>';
+            html += 'Title: <input type="text" data-lang-key="' + langKey + '" data-field="title" value="' + escapeHtml(langVariant.title || '') + '"><br/>';
+            html += 'Speaker: <input type="text" data-lang-key="' + langKey + '" data-field="speaker" value="' + escapeHtml(langVariant.speaker || '') + '"><br/>';
+            html += 'Bible: <input type="text" data-lang-key="' + langKey + '" data-field="bible" value="' + escapeHtml(langVariant.bible || '') + '"><br/>';
+            html += 'Outline:<br/><textarea rows="4" style="width:95%" data-lang-key="' + langKey + '" data-field="outline">' + escapeHtml(langVariant.outline || '') + '</textarea>';
+            html += '</div>';
+        });
+        html += '</div>';
+        html += '<div style="margin-top:10px;">';
+        html += '<label>Add language: <select id="sermon_add_language_select">';
+        sermonLangs.forEach(function(item) {
+            if (sermonData.display_order.indexOf(item.key) === -1) {
+                html += '<option value="' + item.key + '">' + item.display + '</option>';
+            }
+        });
+        html += '</select></label>';
+        html += ' <button type="button" id="sermon_add_language_btn">Add</button>';
+        html += '</div>';
+        return html;
+    }
+
     function get_sermon(id, card) {
         url = API_URL + 'sermon/' + id;
         $.when($.ajax(url)).then(function(response, textStatus, jqXHR) {
             if (response) {
                 var sermon_data = {
                     date: date,
-                    title_en: response.title_en || '',
-                    title_zh: response.title_zh || '',
-                    speaker_en: response.speaker_en || '',
-                    speaker_zh: response.speaker_zh || '',
-                    verse_en: response.bible_en || '',
-                    verse_zh: response.bible_zh || '',
-                    outline_en: response.outline_en || response.outline || '',
-                    outline_zh: response.outline_zh || response.outline || '',
                     notes: response.notes || '',
+                    sermons: {
+                        zh: {
+                            title: (response.sermons && response.sermons.zh && response.sermons.zh.title) || '',
+                            speaker: (response.sermons && response.sermons.zh && response.sermons.zh.speaker) || '',
+                            bible: (response.sermons && response.sermons.zh && response.sermons.zh.bible) || '',
+                            outline: (response.sermons && response.sermons.zh && response.sermons.zh.outline) || ''
+                        },
+                        'zh-TW': {
+                            title: (response.sermons && response.sermons['zh-TW'] && response.sermons['zh-TW'].title) || '',
+                            speaker: (response.sermons && response.sermons['zh-TW'] && response.sermons['zh-TW'].speaker) || '',
+                            bible: (response.sermons && response.sermons['zh-TW'] && response.sermons['zh-TW'].bible) || '',
+                            outline: (response.sermons && response.sermons['zh-TW'] && response.sermons['zh-TW'].outline) || ''
+                        },
+                        en: {
+                            title: (response.sermons && response.sermons.en && response.sermons.en.title) || '',
+                            speaker: (response.sermons && response.sermons.en && response.sermons.en.speaker) || '',
+                            bible: (response.sermons && response.sermons.en && response.sermons.en.bible) || '',
+                            outline: (response.sermons && response.sermons.en && response.sermons.en.outline) || ''
+                        }
+                    },
+                    display_order: (response.display_order && response.display_order.length ? response.display_order : ['zh', 'en']),
                     is_joint: !!response.is_joint
                 };
+                if (sermon_data.display_order.length === 0 || (sermon_data.display_order.length === 1 && sermon_data.display_order[0] === 'zh-TW')) {
+                    sermon_data.display_order = ['zh', 'en'];
+                }
+                var sermonLangs = [
+                    { key: 'zh', label: '中', display: 'Chinese' },
+                    { key: 'zh-TW', label: '台', display: 'Taiwanese' },
+                    { key: 'en', label: 'EN', display: 'English' }
+                ];
                 $("#popup").empty();
-                html = '<div style="min-width:560px;">';
+                html = '<div style="min-width:640px;">';
                 html += '<div style="margin-bottom:8px;">';
                 html += '<label><input type="checkbox" id="is_joint" ' + (response.is_joint ? 'checked' : '') + '> Joint sermon</label>';
                 html += '</div>';
-                html += '<div style="display:flex;gap:12px;flex-wrap:wrap;">';
-                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
-                html += '<div><b>Chinese</b></div>';
-                html += 'Title: <input type="text" id="title_zh" value="' + escapeHtml(response.title_zh || '') + '"><br/>';
-                html += 'Speaker: <input type="text" id="speaker_zh" value="' + escapeHtml(response.speaker_zh || '') + '"><br/>';
-                html += 'Bible: <input type="text" id="verse_zh" value="' + escapeHtml(response.bible_zh || '') + '"><br/>';
-                html += '</div>';
-                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
-                html += '<div><b>English</b></div>';
-                html += 'Title: <input type="text" id="title_en" value="' + escapeHtml(response.title_en || '') + '"><br/>';
-                html += 'Speaker: <input type="text" id="speaker_en" value="' + escapeHtml(response.speaker_en || '') + '"><br/>';
-                html += 'Bible: <input type="text" id="verse_en" value="' + escapeHtml(response.bible_en || '') + '"><br/>';
-                html += '</div>';
-                html += '</div>';
-                html += '<div style="margin-top:10px;">';
-                html += '<div style="display:flex;gap:12px;flex-wrap:wrap;">';
-                html += '<div style="flex:1 1 220px;">';
-                html += '<div><b>Chinese Outline</b></div>';
-                html += '<textarea rows="4" style="width:95%" id="outline_zh">' + escapeHtml(response.outline_zh || response.outline || '') + '</textarea>';
-                html += '</div>';
-                html += '<div style="flex:1 1 220px;">';
-                html += '<div><b>English Outline</b></div>';
-                html += '<textarea rows="4" style="width:95%" id="outline_en">' + escapeHtml(response.outline_en || response.outline || '') + '</textarea>';
-                html += '</div>';
+                html += '<div id="sermon_language_editor" style="border:1px solid #ddd;padding:10px;border-radius:6px;">';
+                html += buildSermonEditorHtml(sermon_data, null, sermonLangs);
                 html += '</div>';
                 html += 'Notes<br/><textarea rows="3" cols="2" style="width:95%" id="notes">' + escapeHtml(response.notes || '') + '</textarea>';
-                html += '</div>';
                 html += '</div>';
                 $("#popup").append(html);
                 $("#popup").dialog({
@@ -416,12 +485,7 @@ let sundays = {{ sundays|safe }};
                                             if (card) {
                                                 var preview = $(card).find('.card-front .sermon-preview-container');
                                                 if (preview.length) {
-                                                    preview.html(
-                                                        (sermon_data.is_joint ? '<div class="joint-badge">Joint</div>' : '') +
-                                                        '<div class="sermon-preview-block"><b>中</b>: ' + escapeHtml(sermon_data.title_zh || '') + '<br/><small>' + escapeHtml(sermon_data.speaker_zh || '') + '</small></div>' +
-                                                        '<div class="sermon-preview-block"><b>EN</b>: ' + escapeHtml(sermon_data.title_en || '') + '<br/><small>' + escapeHtml(sermon_data.speaker_en || '') + '</small></div>' +
-                                                        '<div>Notes: ' + escapeHtml(sermon_data.notes || '') + '</div>'
-                                                    );
+                                                    preview.html(buildSermonPreviewHtml(sermon_data));
                                                 }
                                             }
                                             dialogElement.dialog("close");
@@ -437,13 +501,41 @@ let sundays = {{ sundays|safe }};
                     }]
                 });
                 $('#popup').on('input change', 'input, textarea', function() {
-                    if (this.id === 'notes' || this.id === 'outline_en' || this.id === 'outline_zh') {
-                        sermon_data[this.id] = $(this).val();
+                    if (this.id === 'notes') {
+                        sermon_data.notes = $(this).val();
                     } else if (this.id === 'is_joint') {
                         sermon_data.is_joint = $(this).is(':checked') ? 1 : 0;
-                    } else {
-                        sermon_data[this.id] = $(this).val();
+                    } else if ($(this).data('lang-key')) {
+                        var langKey = $(this).data('lang-key');
+                        var field = $(this).data('field');
+                        if (!sermon_data.sermons[langKey]) {
+                            sermon_data.sermons[langKey] = {};
+                        }
+                        sermon_data.sermons[langKey][field] = $(this).val();
                     }
+                });
+
+                $('#popup').on('click', '#sermon_add_language_btn', function() {
+                    var langKey = $('#sermon_add_language_select').val();
+                    if (!langKey || sermon_data.display_order.indexOf(langKey) !== -1) {
+                        return;
+                    }
+                    if (!sermon_data.sermons[langKey]) {
+                        sermon_data.sermons[langKey] = {};
+                    }
+                    var insertIndex = sermon_data.display_order.indexOf('en');
+                    if (insertIndex === -1) {
+                        insertIndex = sermon_data.display_order.length;
+                    }
+                    sermon_data.display_order.splice(insertIndex, 0, langKey);
+                    $('#sermon_language_editor').html(buildSermonEditorHtml(sermon_data, null, sermonLangs));
+                });
+
+                $('#popup').on('click', '.sermon-remove-lang', function() {
+                    var langKey = $(this).data('lang-key');
+                    sermon_data.display_order = sermon_data.display_order.filter(function(item) { return item !== langKey; });
+                    delete sermon_data.sermons[langKey];
+                    $('#sermon_language_editor').html(buildSermonEditorHtml(sermon_data, null, sermonLangs));
                 });
             }
         });

--- a/web/templates/worship/worship.html
+++ b/web/templates/worship/worship.html
@@ -160,12 +160,12 @@
                                 <div class="joint-badge">Joint</div>
                             {% endif %}
                             <div class="sermon-preview-block">
-                                <b>EN</b>: {{ w.worship.title_en or '' }}<br/>
-                                <small>{{ w.worship.speaker_en or '' }}</small>
-                            </div>
-                            <div class="sermon-preview-block">
                                 <b>中</b>: {{ w.worship.title_zh or '' }}<br/>
                                 <small>{{ w.worship.speaker_zh or '' }}</small>
+                            </div>
+                            <div class="sermon-preview-block">
+                                <b>EN</b>: {{ w.worship.title_en or '' }}<br/>
+                                <small>{{ w.worship.speaker_en or '' }}</small>
                             </div>
                             <div>Notes: {{ (w.worship.notes or '')|string|truncate(100) }}</div>
                         </div>
@@ -209,6 +209,7 @@ let roster;
 let inst;
 let marked;
 let worship_id = -1;
+let activeCard = null;
 let sundays = {{ sundays|safe }};
 
     function pop_role(name) {
@@ -286,7 +287,25 @@ let sundays = {{ sundays|safe }};
         return roster_html;
     }
 
-    function popup(id, date) {
+    function update_card_team_info(card) {
+        if (!card || !roster || !team) {
+            return;
+        }
+        var teamInfo = $(card).find('.card-back .team-info');
+        if (!teamInfo.length) {
+            return;
+        }
+        var html = '<u><b>Worship Team</b></u><br/>';
+        for (var i = 0; i < roster.length; i++) {
+            var entry = roster[i];
+            if (entry.user_name && entry.inst_name) {
+                html += '<b>' + escapeHtml(entry.inst_name) + ':</b>&nbsp;' + escapeHtml(entry.user_name) + '<br/>';
+            }
+        }
+        teamInfo.html(html);
+    }
+
+    function popup(id, date, card) {
         $("#popup").dialog({
             title: "Worship Team (" + date + ")",
             width: 'auto',
@@ -294,8 +313,9 @@ let sundays = {{ sundays|safe }};
                 id: "button-add",
                 text: "OK",
                 click: function() {
-                    $(this).dialog("close");
-                    location.reload();
+                    var dialogElement = $(this);
+                    update_card_team_info(card);
+                    dialogElement.dialog("close");
                 }
             }]
         });
@@ -325,12 +345,20 @@ let sundays = {{ sundays|safe }};
             .replace(/'/g, '&#39;');
     }
 
-    function get_sermon(id) {
+    function get_sermon(id, card) {
         url = API_URL + 'sermon/' + id;
         $.when($.ajax(url)).then(function(response, textStatus, jqXHR) {
             if (response) {
                 var sermon_data = {
                     date: date,
+                    title_en: response.title_en || '',
+                    title_zh: response.title_zh || '',
+                    speaker_en: response.speaker_en || '',
+                    speaker_zh: response.speaker_zh || '',
+                    verse_en: response.bible_en || '',
+                    verse_zh: response.bible_zh || '',
+                    outline_en: response.outline_en || response.outline || '',
+                    outline_zh: response.outline_zh || response.outline || '',
                     notes: response.notes || '',
                     is_joint: !!response.is_joint
                 };
@@ -341,20 +369,29 @@ let sundays = {{ sundays|safe }};
                 html += '</div>';
                 html += '<div style="display:flex;gap:12px;flex-wrap:wrap;">';
                 html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
-                html += '<div><b>English</b></div>';
-                html += 'Title: <input type="text" id="title_en" value="' + escapeHtml(response.title_en || '') + '"><br/>';
-                html += 'Speaker: <input type="text" id="speaker_en" value="' + escapeHtml(response.speaker_en || '') + '"><br/>';
-                html += 'Bible: <input type="text" id="verse_en" value="' + escapeHtml(response.bible_en || '') + '"><br/>';
-                html += '</div>';
-                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
                 html += '<div><b>Chinese</b></div>';
                 html += 'Title: <input type="text" id="title_zh" value="' + escapeHtml(response.title_zh || '') + '"><br/>';
                 html += 'Speaker: <input type="text" id="speaker_zh" value="' + escapeHtml(response.speaker_zh || '') + '"><br/>';
                 html += 'Bible: <input type="text" id="verse_zh" value="' + escapeHtml(response.bible_zh || '') + '"><br/>';
                 html += '</div>';
+                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
+                html += '<div><b>English</b></div>';
+                html += 'Title: <input type="text" id="title_en" value="' + escapeHtml(response.title_en || '') + '"><br/>';
+                html += 'Speaker: <input type="text" id="speaker_en" value="' + escapeHtml(response.speaker_en || '') + '"><br/>';
+                html += 'Bible: <input type="text" id="verse_en" value="' + escapeHtml(response.bible_en || '') + '"><br/>';
+                html += '</div>';
                 html += '</div>';
                 html += '<div style="margin-top:10px;">';
-                html += 'Outline<br/><textarea rows="3" cols="2" style="width:95%" id="outline">' + escapeHtml(response.outline || '') + '</textarea><br/>';
+                html += '<div style="display:flex;gap:12px;flex-wrap:wrap;">';
+                html += '<div style="flex:1 1 220px;">';
+                html += '<div><b>Chinese Outline</b></div>';
+                html += '<textarea rows="4" style="width:95%" id="outline_zh">' + escapeHtml(response.outline_zh || response.outline || '') + '</textarea>';
+                html += '</div>';
+                html += '<div style="flex:1 1 220px;">';
+                html += '<div><b>English Outline</b></div>';
+                html += '<textarea rows="4" style="width:95%" id="outline_en">' + escapeHtml(response.outline_en || response.outline || '') + '</textarea>';
+                html += '</div>';
+                html += '</div>';
                 html += 'Notes<br/><textarea rows="3" cols="2" style="width:95%" id="notes">' + escapeHtml(response.notes || '') + '</textarea>';
                 html += '</div>';
                 html += '</div>';
@@ -366,6 +403,7 @@ let sundays = {{ sundays|safe }};
                         id: "button-add",
                         text: "OK",
                         click: function() {
+                            var dialogElement = $(this);
                             if (!jQuery.isEmptyObject(sermon_data)) {
                                 $.ajax({
                                     type: "post",
@@ -375,19 +413,31 @@ let sundays = {{ sundays|safe }};
                                     dataType: 'json',
                                     complete: function(response) {
                                         if (response.status == 200) {
-                                            location.reload();
+                                            if (card) {
+                                                var preview = $(card).find('.card-front .sermon-preview-container');
+                                                if (preview.length) {
+                                                    preview.html(
+                                                        (sermon_data.is_joint ? '<div class="joint-badge">Joint</div>' : '') +
+                                                        '<div class="sermon-preview-block"><b>中</b>: ' + escapeHtml(sermon_data.title_zh || '') + '<br/><small>' + escapeHtml(sermon_data.speaker_zh || '') + '</small></div>' +
+                                                        '<div class="sermon-preview-block"><b>EN</b>: ' + escapeHtml(sermon_data.title_en || '') + '<br/><small>' + escapeHtml(sermon_data.speaker_en || '') + '</small></div>' +
+                                                        '<div>Notes: ' + escapeHtml(sermon_data.notes || '') + '</div>'
+                                                    );
+                                                }
+                                            }
+                                            dialogElement.dialog("close");
                                         } else {
                                             alert(response.responseText);
                                         }
                                     }
                                 });
+                            } else {
+                                dialogElement.dialog("close");
                             }
-                            $(this).dialog("close");
                         }
                     }]
                 });
                 $('#popup').on('input change', 'input, textarea', function() {
-                    if (this.id === 'notes' || this.id === 'outline') {
+                    if (this.id === 'notes' || this.id === 'outline_en' || this.id === 'outline_zh') {
                         sermon_data[this.id] = $(this).val();
                     } else if (this.id === 'is_joint') {
                         sermon_data.is_joint = $(this).is(':checked') ? 1 : 0;
@@ -480,10 +530,12 @@ $(document).ready(function () {
         else {
             worship_id = Number(id);
             if (this.id == 'team_btn') {
-                popup(id, date);
+                activeCard = $(this).closest('.worship-card');
+                popup(id, date, activeCard);
             }
             else if (this.id == 'sermon_btn') {
-                get_sermon(worship_id);
+                activeCard = $(this).closest('.worship-card');
+                get_sermon(worship_id, activeCard);
             }
         }
     });

--- a/web/templates/worship/worship.html
+++ b/web/templates/worship/worship.html
@@ -116,6 +116,34 @@
         background-color: #008CBA;
         color: #fff;
     }
+
+    .sermon-preview-container {
+        padding: 10px;
+        text-align: left;
+        font-size: 13px;
+        line-height: 1.35;
+    }
+
+    .sermon-preview-block {
+        background: rgba(255,255,255,0.28);
+        border-radius: 6px;
+        padding: 6px 8px;
+        margin-bottom: 6px;
+    }
+
+    .joint-badge {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background: #ffef99;
+        color: #6b4f00;
+        border-radius: 999px;
+        padding: 2px 7px;
+        font-size: 10px;
+        font-weight: bold;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
 </style>
 {% endblock %}
 
@@ -127,11 +155,19 @@
                 <div class="card-front">
                     <h3>{{ w.date }}</h3>
                     {% if w.worship %}
-                        <div style="padding:10px;text-align:left;">
-                            <b>{{ w.worship.sermon_title }}</b><br/>
-                            Speaker: {{ w.worship.speaker }}<br/>
-                            Bible: {{ w.worship.bible }}<br/>
-                            Notes: {{ w.worship.notes|truncate(100) }}
+                        <div class="sermon-preview-container">
+                            {% if w.worship.is_joint %}
+                                <div class="joint-badge">Joint</div>
+                            {% endif %}
+                            <div class="sermon-preview-block">
+                                <b>EN</b>: {{ w.worship.title_en or '' }}<br/>
+                                <small>{{ w.worship.speaker_en or '' }}</small>
+                            </div>
+                            <div class="sermon-preview-block">
+                                <b>中</b>: {{ w.worship.title_zh or '' }}<br/>
+                                <small>{{ w.worship.speaker_zh or '' }}</small>
+                            </div>
+                            <div>Notes: {{ (w.worship.notes or '')|string|truncate(100) }}</div>
                         </div>
                     {% endif %}
                 </div>
@@ -280,13 +316,48 @@ let sundays = {{ sundays|safe }};
         });
     }
 
+    function escapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function get_sermon(id) {
         url = API_URL + 'sermon/' + id;
         $.when($.ajax(url)).then(function(response, textStatus, jqXHR) {
             if (response) {
-                var sermon_data = {};
+                var sermon_data = {
+                    date: date,
+                    notes: response.notes || '',
+                    is_joint: !!response.is_joint
+                };
                 $("#popup").empty();
-                html = 'Title: <input type="text" id="title" value="' + response.title + '"></input><br/>Speaker: <input type="text" id="speaker" value="' + response.speaker + '"></input><br/>&nbsp;Bible: <input type="text" id="bible_verse" value="' + response.bible + '"></input><br/>Outline<br/><textarea rows="3" cols="2" style="width:95%" id="outline">' + response.outline + '</textarea><br/>Notes<br/><textarea rows="3" cols="2" style="width:95%" id="notes">' + response.notes + '</textarea>';
+                html = '<div style="min-width:560px;">';
+                html += '<div style="margin-bottom:8px;">';
+                html += '<label><input type="checkbox" id="is_joint" ' + (response.is_joint ? 'checked' : '') + '> Joint sermon</label>';
+                html += '</div>';
+                html += '<div style="display:flex;gap:12px;flex-wrap:wrap;">';
+                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
+                html += '<div><b>English</b></div>';
+                html += 'Title: <input type="text" id="title_en" value="' + escapeHtml(response.title_en || '') + '"><br/>';
+                html += 'Speaker: <input type="text" id="speaker_en" value="' + escapeHtml(response.speaker_en || '') + '"><br/>';
+                html += 'Bible: <input type="text" id="verse_en" value="' + escapeHtml(response.bible_en || '') + '"><br/>';
+                html += '</div>';
+                html += '<div style="flex:1 1 220px;min-width:220px;border:1px solid #ddd;padding:10px;border-radius:6px;">';
+                html += '<div><b>Chinese</b></div>';
+                html += 'Title: <input type="text" id="title_zh" value="' + escapeHtml(response.title_zh || '') + '"><br/>';
+                html += 'Speaker: <input type="text" id="speaker_zh" value="' + escapeHtml(response.speaker_zh || '') + '"><br/>';
+                html += 'Bible: <input type="text" id="verse_zh" value="' + escapeHtml(response.bible_zh || '') + '"><br/>';
+                html += '</div>';
+                html += '</div>';
+                html += '<div style="margin-top:10px;">';
+                html += 'Outline<br/><textarea rows="3" cols="2" style="width:95%" id="outline">' + escapeHtml(response.outline || '') + '</textarea><br/>';
+                html += 'Notes<br/><textarea rows="3" cols="2" style="width:95%" id="notes">' + escapeHtml(response.notes || '') + '</textarea>';
+                html += '</div>';
+                html += '</div>';
                 $("#popup").append(html);
                 $("#popup").dialog({
                     title: "Sermon Information (" + date + ")",
@@ -296,7 +367,6 @@ let sundays = {{ sundays|safe }};
                         text: "OK",
                         click: function() {
                             if (!jQuery.isEmptyObject(sermon_data)) {
-                                sermon_data["date"] = date;
                                 $.ajax({
                                     type: "post",
                                     url: url,
@@ -316,11 +386,14 @@ let sundays = {{ sundays|safe }};
                         }
                     }]
                 });
-                $('#popup input').change(function() {
-                    sermon_data[this.id] = $(this).val();
-                });
-                $('#popup textarea').change(function() {
-                    sermon_data[this.id] = $(this).val();
+                $('#popup').on('input change', 'input, textarea', function() {
+                    if (this.id === 'notes' || this.id === 'outline') {
+                        sermon_data[this.id] = $(this).val();
+                    } else if (this.id === 'is_joint') {
+                        sermon_data.is_joint = $(this).is(':checked') ? 1 : 0;
+                    } else {
+                        sermon_data[this.id] = $(this).val();
+                    }
                 });
             }
         });


### PR DESCRIPTION
Adds multilingual support for sermons. To test this branch, use the latest worship.db and run the migration.py script on it.

On the utils.py and tools.py side, a lot of logic was written by AI... will need to review it to make sure it is a good idea.

On the database side, we have a "sermon" table that has a new column (is_joint) and now actively uses the _lang_ column. The lang column will be used on the frontend side (for things like rendering sermon blocks and edit popups).

Within utils.py, we are organizing the sermon table for that week into an object of this nature:
```js
{
    "date": "2026-07-12",
    "notes": "...",
    "is_joint": False,
    "sermons": {
        "en": {
            "lang": "en",
            "title": "...",
            "speaker": "...",
            "bible": "...",
            "outline": "..."
        },
        "zh": {
            "lang": "zh",
            "title": "...",
            "speaker": "...",
            "bible": "...",
            "outline": "..."
        }
    }
}
```
